### PR TITLE
feat: implement point sequence and confirm options

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -10,6 +10,7 @@ module.exports = {
 
   flags: {
     FAST_DEV: true,
+    PARALLEL_SOURCING: true,
   },
 
   plugins: ['gatsby-plugin-netlify'],

--- a/package-lock.json
+++ b/package-lock.json
@@ -5229,9 +5229,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001419",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001419.tgz",
-      "integrity": "sha512-aFO1r+g6R7TW+PNQxKzjITwLOyDhVRLjW0LcwS/HCZGUUKTGNp9+IwLC4xyDSZBygVL/mxaFR3HIV6wEKQuSzw==",
+      "version": "1.0.30001718",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001718.tgz",
+      "integrity": "sha512-AflseV1ahcSunK53NfEs9gFWgOEmzr0f+kaMFA4xiLZlr9Hzt7HxcSpIFcnNCUkz6R6dWKa54rUz3HUmI3nVcw==",
       "funding": [
         {
           "type": "opencollective",
@@ -5240,8 +5240,13 @@
         {
           "type": "tidelift",
           "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
         }
-      ]
+      ],
+      "license": "CC-BY-4.0"
     },
     "node_modules/capital-case": {
       "version": "1.0.4",
@@ -19258,9 +19263,9 @@
       }
     },
     "caniuse-lite": {
-      "version": "1.0.30001419",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001419.tgz",
-      "integrity": "sha512-aFO1r+g6R7TW+PNQxKzjITwLOyDhVRLjW0LcwS/HCZGUUKTGNp9+IwLC4xyDSZBygVL/mxaFR3HIV6wEKQuSzw=="
+      "version": "1.0.30001718",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001718.tgz",
+      "integrity": "sha512-AflseV1ahcSunK53NfEs9gFWgOEmzr0f+kaMFA4xiLZlr9Hzt7HxcSpIFcnNCUkz6R6dWKa54rUz3HUmI3nVcw=="
     },
     "capital-case": {
       "version": "1.0.4",

--- a/src/api/client.js
+++ b/src/api/client.js
@@ -5,6 +5,16 @@ export const supabase = createClient(
   'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJyb2xlIjoiYW5vbiIsImlhdCI6MTYzNTI0Nzg1MCwiZXhwIjoxOTUwODIzODUwfQ.bsG7ieEq9-tpfwACvQ_T-5DTU-xWyX2fWb3JezQFqdg'
 );
 
-export const removeSubscription = subscription => {
-  supabase.removeSubscription(subscription);
+export const addSubscription = (session, dbTable, callback) => {
+  return supabase
+    .from(`${dbTable}:session_name=eq.${session}`)
+    .on('*', payload => {
+      console.log(`${dbTable} change received`, payload);
+      callback(payload);
+    })
+    .subscribe();
+};
+
+export const removeSubscription = subscriptionId => {
+  supabase.removeSubscription(subscriptionId);
 };

--- a/src/api/options.js
+++ b/src/api/options.js
@@ -1,0 +1,39 @@
+import { supabase } from './client';
+
+export const OPT_CONFIRM_DEFAULT = 'true';
+export const OPT_CONFIRM_KEY = 'confirm';
+
+export const OPT_POINT_SEQ_DEFAULT = 'standard';
+export const OPT_POINT_KEY = 'point_sequence';
+
+export const submitOption = async (session, optionKey, value) => {
+  const { error } = await supabase
+    .from('options')
+    .upsert([
+      { key: optionKey, value: value?.toString() || '', session_name: session },
+    ]);
+
+  if (error && !Array.isArray(error)) {
+    const errStr = JSON.stringify(error);
+    throw new Error(errStr);
+  }
+};
+
+export const fetchOption = async (session, optionKey, defaultValue) => {
+  let { data: options, error } = await supabase
+    .from('options')
+    .select('key,value,session_name')
+    .eq('session_name', session)
+    .eq('key', optionKey);
+
+  if (error && !Array.isArray(error)) {
+    const errStr = JSON.stringify(error);
+    throw new Error(errStr);
+  }
+
+  if (options?.length > 0) {
+    return options[0].value;
+  }
+
+  return defaultValue;
+};

--- a/src/api/scores.js
+++ b/src/api/scores.js
@@ -1,18 +1,22 @@
 import { supabase } from './client';
 
-export const submitScore = async (userId, session, score) => {
-  const { error } = await supabase
-    .from('scores')
-    .upsert([
-      { score, user_id: userId, session_name: session, updated_at: new Date(), revealed: false },
-    ]);
+export const submitScore = async (session, userId, score) => {
+  const { error } = await supabase.from('scores').upsert([
+    {
+      score,
+      user_id: userId,
+      session_name: session,
+      updated_at: new Date(),
+      revealed: false,
+    },
+  ]);
 
   if (error && !Array.isArray(error)) {
     throw new Error(JSON.stringify(error));
   }
 };
 
-export const deleteScore = async (userId, session) => {
+export const deleteScore = async (session, userId) => {
   const { error } = await supabase
     .from('scores')
     .delete()
@@ -22,7 +26,6 @@ export const deleteScore = async (userId, session) => {
     throw new Error(JSON.stringify(error));
   }
 };
-
 
 export const resetScores = async session => {
   const { error } = await supabase
@@ -45,7 +48,8 @@ export const updateAllScores = async (session, revealed) => {
     throw new Error(JSON.stringify(error));
   }
 };
-export const getScores = async session => {
+
+export const fetchScores = async session => {
   const { data: scores, error } = await supabase
     .from('scores')
     .select('user_id,score,revealed')
@@ -56,16 +60,4 @@ export const getScores = async session => {
   }
 
   return scores;
-};
-
-export const onNewScores = (session, callback) => {
-  const subscription = supabase
-    .from('scores')
-    .on('*', payload => {
-      console.log('Change received!', payload);
-      callback(payload);
-    })
-    .subscribe();
-
-  return subscription;
 };

--- a/src/api/scores.js
+++ b/src/api/scores.js
@@ -1,5 +1,15 @@
 import { supabase } from './client';
 
+// Score icons use negative numbers so math functions can skip them
+export const ICON_SCORE_MAP = {
+  '☕': -2,
+  '?': -1,
+};
+export const SCORE_ICON_MAP = {};
+for (const [k, v] of Object.entries(ICON_SCORE_MAP)) {
+  SCORE_ICON_MAP[v.toString()] = k;
+}
+
 export const submitScore = async (session, userId, score) => {
   const { error } = await supabase.from('scores').upsert([
     {

--- a/src/api/users.js
+++ b/src/api/users.js
@@ -1,6 +1,6 @@
 import { supabase } from './client';
 
-export const createUser = async (username, session) => {
+export const createUser = async (session, username) => {
   const { data: newUser, error } = await supabase
     .from('users')
     .insert([{ name: username, session_name: session }]);
@@ -12,7 +12,7 @@ export const createUser = async (username, session) => {
   return newUser[0];
 };
 
-export const updateUserPresence = async (userId, session, last_presence) => {
+export const updateUserPresence = async (session, userId, last_presence) => {
   if (!userId) return;
   const { error } = await supabase
     .from('users')
@@ -24,7 +24,7 @@ export const updateUserPresence = async (userId, session, last_presence) => {
   }
 };
 
-export const getAllUsers = async session => {
+export const fetchAllUsers = async session => {
   let { data: users, error } = await supabase
     .from('users')
     .select('*')
@@ -37,7 +37,7 @@ export const getAllUsers = async session => {
   return users;
 };
 
-export const getUser = async userId => {
+export const fetchUser = async userId => {
   if (!userId) return;
 
   let { data: user, error } = await supabase

--- a/src/components/Hero/index.jsx
+++ b/src/components/Hero/index.jsx
@@ -44,7 +44,7 @@ export const Hero = () => {
     if (typeof window === 'undefined') {
       return;
     }
-    window.location.href += `#${nanoid(7)}`;
+    window.location.hash = nanoid(7);
   };
 
   return (

--- a/src/components/Layout/common.css
+++ b/src/components/Layout/common.css
@@ -14,8 +14,10 @@
 
   /*Fixed colours*/
   --color-discord-blue: #7289da;
+  --color-warning-yellow: #dab936;
   --color-warning-red: #f44336;
 
+  /*Fixed styles*/
   --display-mobile-breakpoint: 768px;
 }
 
@@ -30,9 +32,6 @@
   /*Inverted colours*/
   --inverted-bg-color: #f7f5eb;
   --inverted-text-color: #333;
-
-  /*Fixed colours*/
-  --color-discord-blue: #7289da;
 }
 
 * {

--- a/src/components/ModeratorControls/index.jsx
+++ b/src/components/ModeratorControls/index.jsx
@@ -3,7 +3,15 @@ import { toast } from 'react-toastify';
 import { resetScores } from '../../api/scores';
 import * as styles from './moderatorcontrols.module.css';
 
-export const ModeratorControls = ({ session, showScores, toggleScores }) => {
+export const ModeratorControls = ({
+  session,
+  showScores,
+  toggleScores,
+  confirmEnabled,
+  toggleConfirm,
+  nextSequence,
+  cycleSequence,
+}) => {
   const [isModerator, setIsModerator] = React.useState(false);
 
   React.useEffect(() => {
@@ -12,6 +20,13 @@ export const ModeratorControls = ({ session, showScores, toggleScores }) => {
     }
   }, [isModerator]);
 
+  const confirm = msg => {
+    if (!confirmEnabled) {
+      return true;
+    }
+    return window.confirm(msg);
+  };
+
   const reset = React.useCallback(() => {
     toggleScores(false); // Only change visuals
     resetScores(session);
@@ -19,31 +34,57 @@ export const ModeratorControls = ({ session, showScores, toggleScores }) => {
 
   if (!isModerator) {
     return (
-      <span
+      <button
         className={styles.moderator_notice}
         onClick={() => setIsModerator(true)}
       >
-        click to enable moderator controls
-      </span>
+        Show Moderator Controls
+      </button>
     );
   }
 
   return (
-    <div className={styles.actions}>
-      <div
-        className={styles.reveal}
-        onClick={() =>
-          window.confirm(`${showScores ? 'Hide' : 'Reveal'} all cards?`) &&
-          toggleScores(true)
-        }
+    <div className={styles.moderator_controls}>
+      <button
+        className={styles.moderator_notice}
+        onClick={() => setIsModerator(false)}
       >
-        {showScores ? 'Hide' : 'Reveal'}
+        Hide Moderator Controls
+      </button>
+      <div className={styles.actions}>
+        <div
+          className={styles.reveal}
+          onClick={() =>
+            confirm(`${showScores ? 'Hide' : 'Reveal'} all cards?`) &&
+            toggleScores(true)
+          }
+        >
+          {showScores ? 'Hide' : 'Reveal'}
+        </div>
+        <div
+          className={styles.reset}
+          onClick={() => confirm('Reset all cards?') && reset()}
+        >
+          Reset
+        </div>
       </div>
-      <div
-        className={styles.reset}
-        onClick={() => window.confirm('Reset all cards?') && reset()}
-      >
-        Reset
+      <div className={styles.options}>
+        <div
+          className={styles.confirm}
+          onClick={() =>
+            confirm('Disable your confirmation dialog?') && toggleConfirm()
+          }
+        >
+          {confirmEnabled ? 'Disable' : 'Enable'} Confirm
+        </div>
+        <div
+          className={styles.sequence}
+          onClick={() =>
+            confirm(`Use ${nextSequence} cards?`) && cycleSequence()
+          }
+        >
+          Use {nextSequence} Cards
+        </div>
       </div>
     </div>
   );

--- a/src/components/ModeratorControls/index.jsx
+++ b/src/components/ModeratorControls/index.jsx
@@ -27,10 +27,24 @@ export const ModeratorControls = ({
     return window.confirm(msg);
   };
 
+  const removeSelected = () => {
+    const cardElements = document.querySelectorAll('[id^="score_val_"]');
+    cardElements.forEach(card => {
+      card.style.backgroundColor = '';
+      card.style.borderColor = '';
+    });
+  };
+
   const reset = React.useCallback(() => {
     toggleScores(false); // Only change visuals
+    removeSelected();
     resetScores(session);
   }, [session, toggleScores]);
+
+  const changePoints = React.useCallback(() => {
+    reset();
+    cycleSequence();
+  }, [cycleSequence, reset]);
 
   if (!isModerator) {
     return (
@@ -80,7 +94,7 @@ export const ModeratorControls = ({
         <div
           className={styles.sequence}
           onClick={() =>
-            confirm(`Use ${nextSequence} cards?`) && cycleSequence()
+            confirm(`Use ${nextSequence} cards?`) && changePoints()
           }
         >
           Use {nextSequence} Cards

--- a/src/components/ModeratorControls/moderatorcontrols.module.css
+++ b/src/components/ModeratorControls/moderatorcontrols.module.css
@@ -1,33 +1,58 @@
-
 .moderator_notice {
     color: var(--text-color-subtle);
-    margin: 32px 0;
+    text-transform: capitalize;
+    width: auto;
+    padding: 1rem;
+    margin: 1rem auto;
+    background-color: var(--bg-color);
+    border-radius: 1rem;
 }
 
-.actions {
-    display: flex;
-    justify-content: center;
-    margin: 64px 0;
-  }
-
-.actions > div {
-    display: inline;
-    width: 100px;
-    padding: 30px 20px;
-    border-radius: 10%;
-    margin: 5px;
-    background-color: var(--bg-color);
-  }
-  .actions > div:hover {
-      background-color: var(--bg-color-2);
+.moderator_notice:hover {
+    background-color: var(--bg-color-2);
     cursor: pointer;
-  }
-  
-  .reveal {
+}
+
+.moderator_controls {
+    display: flex;
+    flex-direction: column;
+    text-align: center;
+}
+
+.moderator_controls .actions, .moderator_controls .options {
+    display: flex;
+    flex-flow: row wrap;
+    justify-content: center;
+    margin: 0 0 0.5rem;
+}
+
+.moderator_controls .actions > div, .moderator_controls .options > div {
+    display: inline;
+    text-transform: capitalize;
+    width: auto;
+    padding: 1.5rem;
+    margin: 0.5rem;
+    background-color: var(--bg-color);
+    border-radius: 1rem;
+}
+
+.moderator_controls .actions > div:hover, .moderator_controls .options > div:hover {
+    background-color: var(--bg-color-2);
+    cursor: pointer;
+}
+
+.moderator_controls .actions .reveal {
     border: 1px solid var(--color-discord-blue);
-  }
-  
-  .reset {
+}
+
+.moderator_controls .actions .reset {
     border: 1px solid var(--color-warning-red);
-  }
-  
+}
+
+.moderator_controls .options .confirm {
+    border: 1px solid var(--color-warning-yellow);
+}
+
+.moderator_controls .options .sequence {
+    border: 1px solid var(--color-warning-yellow);
+}

--- a/src/components/PlanningPoker/index.jsx
+++ b/src/components/PlanningPoker/index.jsx
@@ -3,6 +3,14 @@ import { Helmet } from 'react-helmet';
 import { toast } from 'react-toastify';
 import { useCopyToClipboard } from 'react-use';
 import { addSubscription, removeSubscription } from '../../api/client';
+import {
+  fetchOption,
+  submitOption,
+  OPT_CONFIRM_DEFAULT,
+  OPT_CONFIRM_KEY,
+  OPT_POINT_SEQ_DEFAULT,
+  OPT_POINT_KEY,
+} from '../../api/options';
 import { fetchScores, updateAllScores } from '../../api/scores';
 import {
   createUser,
@@ -17,7 +25,12 @@ import * as styles from './planningpoker.module.css';
 
 // This is a special value that will trigger deleteing a score.
 const REMOVE_SCORE = '-';
-const POINTS = [REMOVE_SCORE, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
+const POINT_SEQUENCES = {
+  fibonacci: [REMOVE_SCORE, 1, 2, 3, 5, 8, 13, 21, 34, 55, 89],
+  scrum: [REMOVE_SCORE, '☕', '?', 0, 1, 2, 3, 5, 8, 13, 20, 40, 100],
+  standard: [REMOVE_SCORE, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
+};
+const POINT_SEQUENCES_SORTED = Object.keys(POINT_SEQUENCES).sort();
 
 function parseISOString(s) {
   var b = s.split(/\D+/);
@@ -48,8 +61,17 @@ export const PlanningPoker = ({ session, user: localUser }) => {
   const [user, setUser] = React.useState();
   const [users, setUsers] = React.useState([]);
   const [scores, setScores] = React.useState([]);
+  const [confirmEnabled, setConfirmEnabled] = React.useState(
+    OPT_CONFIRM_DEFAULT === 'true'
+  );
+  const [sequence, setSequence] = React.useState(OPT_POINT_SEQ_DEFAULT);
 
   const showScores = scores.length && scores.every(score => score.revealed);
+  const nextSequence =
+    POINT_SEQUENCES_SORTED[
+      (POINT_SEQUENCES_SORTED.indexOf(sequence) + 1) %
+        POINT_SEQUENCES_SORTED.length
+    ];
 
   const updateUsers = async session => {
     const users = await fetchAllUsers(session);
@@ -102,6 +124,16 @@ export const PlanningPoker = ({ session, user: localUser }) => {
     setScores(scores => [...scores.filter(score => score.user_id !== oldUser)]);
   };
 
+  const updateSessionOptions = async session => {
+    const pointSequence = await fetchOption(
+      session,
+      OPT_POINT_KEY,
+      OPT_POINT_SEQ_DEFAULT
+    );
+    setSequence(pointSequence);
+    // Confirm option is per-user, so not set for all users in session
+  };
+
   React.useEffect(() => {
     const subcriptionId = addSubscription(session, 'scores', payload => {
       if (payload.eventType === 'DELETE') {
@@ -111,6 +143,24 @@ export const PlanningPoker = ({ session, user: localUser }) => {
       }
     });
     updateScores(session);
+    return () => removeSubscription(subcriptionId);
+  }, [session]);
+
+  React.useEffect(() => {
+    const subcriptionId = addSubscription(session, 'options', payload => {
+      switch (payload.new?.key) {
+        case OPT_CONFIRM_KEY:
+          setConfirmEnabled(payload.new?.value === 'true');
+          break;
+        case OPT_POINT_KEY:
+          setSequence(payload.new?.value || OPT_POINT_SEQ_DEFAULT);
+          break;
+        default:
+          console.warn('Unknown option change', payload);
+          break;
+      }
+    });
+    updateSessionOptions(session);
     return () => removeSubscription(subcriptionId);
   }, [session]);
 
@@ -152,6 +202,18 @@ export const PlanningPoker = ({ session, user: localUser }) => {
     [session, showScores]
   );
 
+  const toggleConfirm = React.useCallback(() => {
+    console.log('Toggling confirm', !confirmEnabled);
+    // Confirm option is per-user only, so set locally but not in the session database
+    setConfirmEnabled(!confirmEnabled);
+  }, [confirmEnabled]);
+
+  const cycleSequence = React.useCallback(() => {
+    console.log('Cycling sequence', nextSequence);
+    submitOption(session, OPT_POINT_KEY, nextSequence);
+    setSequence(nextSequence);
+  }, [session, nextSequence]);
+
   return (
     <>
       <Helmet>
@@ -159,8 +221,18 @@ export const PlanningPoker = ({ session, user: localUser }) => {
       </Helmet>
       <CopySession sessionId={session} />
       <UserList me={user} users={users} scores={scores} />
-      <ScoreCards session={session} options={POINTS} />
-      <ModeratorControls {...{ session, showScores, toggleScores }} />
+      <ScoreCards session={session} options={POINT_SEQUENCES[sequence]} />
+      <ModeratorControls
+        {...{
+          session,
+          showScores,
+          toggleScores,
+          confirmEnabled,
+          toggleConfirm,
+          nextSequence,
+          cycleSequence,
+        }}
+      />
     </>
   );
 };

--- a/src/components/ScoreCards/index.jsx
+++ b/src/components/ScoreCards/index.jsx
@@ -8,10 +8,27 @@ export const ScoreCards = ({ options, session }) => {
     const user = JSON.parse(localStorage.getItem('user'));
     if (!user.id) return;
 
-    if (value === '-') {
+    const deleteValue = '-';
+    if (value === deleteValue) {
       deleteScore(session, user.id);
     } else {
       submitScore(session, user.id, ICON_SCORE_MAP[value] || value);
+    }
+
+    const cardElements = document.querySelectorAll('[id^="score_val_"]');
+    cardElements.forEach(card => {
+      card.style.backgroundColor = '';
+      card.style.borderColor = '';
+    });
+
+    if (value !== deleteValue) {
+      const cardElement = document.getElementById(
+        `score_val_${ICON_SCORE_MAP[value] || value}`
+      );
+      if (cardElement) {
+        cardElement.style.backgroundColor = 'var(--bg-color-2)';
+        cardElement.style.borderColor = 'var(--color-discord-blue)';
+      }
     }
   };
 
@@ -20,7 +37,8 @@ export const ScoreCards = ({ options, session }) => {
       <div className={styles.options}>
         {options.map(opt => (
           <div
-            key={ICON_SCORE_MAP[opt] || opt}
+            key={`${ICON_SCORE_MAP[opt] || opt}`}
+            id={`score_val_${ICON_SCORE_MAP[opt] || opt}`}
             className={styles.card}
             onClick={() => onSelectCard(opt)}
           >

--- a/src/components/ScoreCards/index.jsx
+++ b/src/components/ScoreCards/index.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { submitScore, deleteScore } from '../../api/scores';
+import { submitScore, deleteScore, ICON_SCORE_MAP } from '../../api/scores';
 
 import * as styles from './scorecards.module.css';
 
@@ -11,7 +11,7 @@ export const ScoreCards = ({ options, session }) => {
     if (value === '-') {
       deleteScore(session, user.id);
     } else {
-      submitScore(session, user.id, value);
+      submitScore(session, user.id, ICON_SCORE_MAP[value] || value);
     }
   };
 
@@ -20,7 +20,7 @@ export const ScoreCards = ({ options, session }) => {
       <div className={styles.options}>
         {options.map(opt => (
           <div
-            key={opt}
+            key={ICON_SCORE_MAP[opt] || opt}
             className={styles.card}
             onClick={() => onSelectCard(opt)}
           >

--- a/src/components/ScoreCards/index.jsx
+++ b/src/components/ScoreCards/index.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { resetScores, submitScore, deleteScore } from '../../api/scores';
+import { submitScore, deleteScore } from '../../api/scores';
 
 import * as styles from './scorecards.module.css';
 
@@ -9,9 +9,9 @@ export const ScoreCards = ({ options, session }) => {
     if (!user.id) return;
 
     if (value === '-') {
-      deleteScore(user.id, session);
+      deleteScore(session, user.id);
     } else {
-      submitScore(user.id, session, value);
+      submitScore(session, user.id, value);
     }
   };
 

--- a/src/components/ScoreCards/scorecards.module.css
+++ b/src/components/ScoreCards/scorecards.module.css
@@ -2,24 +2,25 @@
   display: flex;
   flex-direction: column;
   text-align: center;
-  margin-top: 64px;
+  margin-top: 2rem;
 }
 
-.options {
+.card_container .options {
   display: flex;
-  width: 100%;
   justify-content: space-evenly;
+  width: 100%;
+  margin: 0 0 2rem;
 }
 
 .card {
   display: flex;
   justify-content: center;
   align-items: center;
-  height: 90px;
-  width: 60px;
+  height: 5rem;
+  width: 3rem;
   border: 1px solid var(--text-color);
   border-radius: 10%;
-  margin: 5px;
+  margin: 0.25rem;
   background-color: var(--bg-color);
   cursor: pointer;
 }
@@ -33,10 +34,10 @@
 }
 .actions > div {
   display: inline;
-  width: 100px;
-  padding: 30px 20px;
+  width: 3rem;
+  padding: 1rem;
   border-radius: 10%;
-  margin: 5px;
+  margin: 0.25rem;
   background-color: var(--bg-color);
 }
 .actions > div:hover {
@@ -53,8 +54,18 @@
 }
 
 .moderator_notice {
-  color: var(--text-color-subtle);
-  margin: 16px 0;
+    color: var(--text-color-subtle);
+    text-transform: capitalize;
+    width: auto;
+    padding: 1rem;
+    margin: 1rem auto;
+    background-color: var(--bg-color);
+    border-radius: 1rem;
+}
+
+.moderator_notice:hover {
+    background-color: var(--bg-color-2);
+    cursor: pointer;
 }
 
 @media (max-width: 768px) {

--- a/src/components/UserList/index.jsx
+++ b/src/components/UserList/index.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import * as styles from './userlist.module.css';
+import { SCORE_ICON_MAP } from '../../api/scores';
 
 const standardDeviation = array => {
   const n = array.length;
@@ -13,21 +14,34 @@ const standardDeviation = array => {
 const average = arr => arr.reduce((p, c) => p + c, 0) / arr.length;
 
 export const UserList = ({ me, users, scores }) => {
-  const [vibrating, setVibrating] = React.useState(false);
+  // const [vibrating, setVibrating] = React.useState(false);
+  // All math functions skip negative scores (that icons use)
   let lowest = React.useMemo(
-    () => Math.min(...scores.map(score => score.score)),
+    () =>
+      Math.min(
+        ...scores.filter(score => score.score >= 0).map(score => score.score)
+      ),
     [scores]
   );
   let highest = React.useMemo(
-    () => Math.max(...scores.map(score => score.score)),
+    () =>
+      Math.max(
+        ...scores.filter(score => score.score >= 0).map(score => score.score)
+      ),
     [scores]
   );
   let stddev = React.useMemo(
-    () => standardDeviation(scores.map(score => score.score)),
+    () =>
+      standardDeviation(
+        scores.filter(score => score.score >= 0).map(score => score.score)
+      ),
     [scores]
   );
   let avg = React.useMemo(
-    () => average(scores.map(score => score.score)),
+    () =>
+      average(
+        scores.filter(score => score.score >= 0).map(score => score.score)
+      ),
     [scores]
   );
   const scoreByUser = {};
@@ -56,11 +70,16 @@ export const UserList = ({ me, users, scores }) => {
   try {
     if (showScores) {
       // Try to sort by score as well.
-      users?.sort((a,b) => (scoreByUser[b.id]?.score ?? 0) - (scoreByUser[a.id]?.score ?? 0));
+      users?.sort(
+        (a, b) =>
+          (scoreByUser[b.id]?.score ?? 0) - (scoreByUser[a.id]?.score ?? 0)
+      );
     }
-  } catch (e) { console.error(e); }
-  console.log({users})
-  
+  } catch (e) {
+    console.error(e);
+  }
+  console.log({ users });
+
   const resetName = () => {
     if (typeof window === 'undefined') {
       return;
@@ -76,7 +95,11 @@ export const UserList = ({ me, users, scores }) => {
     if (!score.revealed && !isMe) {
       return <div className={styles.score}>?</div>;
     }
-    return <div className={styles.score}>{score.score}</div>;
+    return (
+      <div className={styles.score}>
+        {SCORE_ICON_MAP[score.score.toString()] || score.score}
+      </div>
+    );
   };
 
   const User = ({ user }) => {
@@ -100,7 +123,11 @@ export const UserList = ({ me, users, scores }) => {
   };
 
   return (
-    <div className={`${styles.user_list} ${users?.length > 5 && styles.two_columns} ${showScores && styles.show_scores}`}>
+    <div
+      className={`${styles.user_list} ${
+        users?.length > 5 && styles.two_columns
+      } ${showScores && styles.show_scores}`}
+    >
       {users?.map(user => (
         <User key={user.id} user={user} />
       ))}


### PR DESCRIPTION
### Description

* Add new option for changing the point sequence from current standard counting sequence (1, 2, 3, 4, 5, etc) to fibonacci (1, 2, 3, 5, 8, etc) or scrum style (☕, ?, 0, 1, 2, 3, 5, 8, etc)
* Add new option to disable confirmation dialog
* Slight tweaks to CSS styling to use `rem` more than `px/%` for better rounded corners and similar spacing consistency.
* Add selected card highlight

### Tests

[X] Manual testing using `npx gatsby develop` locally
[X] Testing using Chrome dev tools to mimic mobile device
[X] Tested behavior with multiple users in a session

### Showcase

#### Showing new options in moderator controls using Fibonacci sequence option and selected card

<img width="665" alt="Screenshot 2025-05-27 at 16 20 00" src="https://github.com/user-attachments/assets/786d4429-8381-431e-a91c-a960bd1f1bbf" />

#### Scrum cards showing math functions still work when icon vote cast

<img width="1024" alt="Screenshot 2025-05-27 at 15 09 20" src="https://github.com/user-attachments/assets/4f440964-e197-404b-92f2-1a704749664f" />

#### Showing mobile layout

<img width="403" alt="Screenshot 2025-05-27 at 15 09 42" src="https://github.com/user-attachments/assets/bf424a5a-2da3-4da4-8de3-2954bcbf3341" />