### PR TITLE
feat: spectators and improved session management

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -27,7 +27,8 @@ jobs:
           node-version: '24'
           cache: 'npm'
       - run: npm ci --prefer-offline --no-audit
-      - run: npm run build:prefixed
+      - run: npm run lint
+      - run: npm run build
       # - name: Deploy
       #   uses: peaceiris/actions-gh-pages@v3
       #   with:

--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ If deploying under a subpath, set `DEPLOY_TARGET` in Netlify build environment v
 The app reads and writes directly to Supabase from the browser. It expects these public tables:
 
 - `users`: session members and their `last_presence`
+- `users`: session members with `is_spectator` role and `last_presence`
 - `scores`: one score per user per session
 - `options`: per-session settings (point sequence, stage, moderators, confirmations)
 - `rounds`: historical snapshots saved when returning from results to voting

--- a/README.md
+++ b/README.md
@@ -10,16 +10,16 @@ A planning poker application built with Next.js and React.
 
 _Have an idea you want to suggest? Pull requests are welcome._
 
-## Quick start
+## Quick Start
 
-1. Clone the repo and install dependencies.
+1. Clone and install dependencies.
 
 ```shell
 git clone <url> .
 npm install
 ```
 
-2. Start the development server.
+2. Start local development.
 
 ```shell
 npm run dev
@@ -27,23 +27,47 @@ npm run dev
 
 3. Open `http://localhost:3000/`.
 
-## Build and deploy
+## Scripts
 
-Build the app:
+- `npm run dev`: start Next.js in development mode
+- `npm run build`: production build
+- `npm run start`: run the production server from a completed build
+- `npm run lint`: run ESLint
+- `npm run format`: run Prettier across source and docs
+
+## Build And CI
+
+Local production check:
 
 ```shell
+npm run lint
 npm run build
 ```
 
-Start the production server:
+GitHub Actions build workflow is in [.github/workflows/deploy.yml](.github/workflows/deploy.yml) and currently runs:
+
+1. `npm ci --prefer-offline --no-audit`
+2. `npm run lint`
+3. `npm run build`
+
+## Deployment Variants
+
+Routing behavior is configured in [next.config.mjs](next.config.mjs):
+
+- Root deployment (default): do not set `DEPLOY_TARGET`
+- Subpath deployment: set `DEPLOY_TARGET=<subpath>`
+
+Example for GitHub Pages style hosting:
 
 ```shell
-npm run start
+DEPLOY_TARGET=planning-poker npm run build
 ```
 
-### Netlify deployment
+This applies both `basePath` and `assetPrefix` to `/<DEPLOY_TARGET>`.
 
-The repo includes a `netlify.toml` that configures Netlify to build with Next.js using the Essential Next.js plugin:
+### Netlify
+
+The repo includes [netlify.toml](netlify.toml) with the Essential Next.js plugin.
 
 ```toml
 [build]
@@ -54,23 +78,76 @@ The repo includes a `netlify.toml` that configures Netlify to build with Next.js
   package = "@netlify/plugin-nextjs"
 ```
 
-Netlify will automatically install `@netlify/plugin-nextjs` at build time. If you need to deploy under a subpath such as `/planning-poker`, set `DEPLOY_TARGET=planning-poker` for the build.
+If deploying under a subpath, set `DEPLOY_TARGET` in Netlify build environment variables.
 
-## Supabase schema
+## Supabase Schema Bootstrap
 
-The app reads and writes directly to Supabase from the browser, and expects three public tables:
+The app reads and writes directly to Supabase from the browser. It expects these public tables:
 
 - `users`: session members and their `last_presence`
 - `scores`: one score per user per session
-- `options`: per-session settings such as the point sequence
+- `options`: per-session settings (point sequence, stage, moderators, confirmations)
+- `rounds`: historical snapshots saved when returning from results to voting
 
-To recreate the schema, run [supabase/schema.sql](supabase/schema.sql) in the Supabase SQL editor. The script:
+To recreate schema and policies, run [supabase/schema.sql](supabase/schema.sql) in the Supabase SQL editor.
 
-- recreates the `users`, `scores`, and `options` tables
-- adds `created_at` and `updated_at` columns for debugging
-- creates the composite keys required by the app's `upsert()` calls
-- enables RLS with permissive anon/authenticated policies so the current client continues to work
-- adds `scores` and `options` to `supabase_realtime`
+The script will:
+
+- recreate `users`, `scores`, `options`, and `rounds`
+- create `created_at` and `updated_at` timestamps and update triggers
+- apply keys/indexes needed by upsert and session filters
+- enable RLS with permissive anon/authenticated policies
+- add realtime publication for `scores`, `options`, and `rounds`
+
+## Runtime Notes
+
+### Session Routing
+
+- Session id comes from URL hash (`/voting#abc1234`)
+- Without a hash, app generates or redirects to a valid voting route
+- `results` and `options` routes require both hash session and a locally stored user for that session
+
+### Local User Storage
+
+User storage is session-aware in [src/utils/userStorage.js](src/utils/userStorage.js):
+
+- stores a preferred name profile
+- stores per-session user memberships keyed by session hash
+- avoids one session identity overwriting another session identity
+
+### Realtime Synchronization
+
+Session state and rounds state use guarded refreshes in [src/hooks/useSessionState.js](src/hooks/useSessionState.js) and [src/hooks/useRounds.js](src/hooks/useRounds.js):
+
+- subscriptions trigger canonical refetches
+- stale async responses are ignored when session/request token no longer matches
+- roster updates subscribe to `users` events for faster convergence
+
+## Troubleshooting
+
+### `npm run dev` exits unexpectedly
+
+1. Confirm Node version matches CI expectation (`node-version: '24'` in workflow).
+2. Reinstall dependencies: `npm ci`.
+3. Run lint/build to surface issues quickly:
+
+```shell
+npm run lint
+npm run build
+```
+
+### Session opens but user list or scores seem stale
+
+1. Verify all clients are in the same hash session id.
+2. Confirm Supabase realtime includes `scores`, `options`, and `rounds` tables.
+3. Confirm `users` rows are being updated with recent `last_presence`.
+4. Refresh page to force a full state bootstrap.
+
+### Options or stage do not propagate
+
+1. Confirm `options` table exists and RLS allows read/write.
+2. Confirm key names in table include expected values (`stage`, `point_sequence`, `confirm`, `moderators`).
+3. Check browser console for Supabase channel errors.
 
 ## Project structure
 

--- a/pages/debug.jsx
+++ b/pages/debug.jsx
@@ -4,6 +4,7 @@ import { fetchAllUsers } from '../src/api/users';
 import { fetchScores } from '../src/api/scores';
 import { fetchRounds } from '../src/api/rounds';
 import { supabase } from '../src/api/client';
+import { getStoredUser, getStoredUserName } from '../src/utils/userStorage';
 
 const Section = ({ title, data }) => (
   <section style={{ marginBottom: '2rem' }}>
@@ -52,8 +53,10 @@ const Debug = () => {
 
     setSession(hashSession);
 
-    const stored = JSON.parse(localStorage.getItem('user') || 'null');
-    setLocalUser(stored);
+    setLocalUser({
+      preferredName: getStoredUserName(),
+      sessionUser: getStoredUser(hashSession),
+    });
 
     const load = async () => {
       try {

--- a/pages/options.jsx
+++ b/pages/options.jsx
@@ -1,35 +1,11 @@
 import React from 'react';
 import Head from 'next/head';
-import { useRouter } from 'next/router';
 import Layout from '../src/components/Layout';
 import { OptionsScreen } from '../src/components/OptionsScreen';
-import { getStoredUser } from '../src/utils/userStorage';
+import { useHashSession } from '../src/hooks/useHashSession';
 
 const Options = () => {
-  const router = useRouter();
-  const [session, setSession] = React.useState('');
-  const [user, setUser] = React.useState();
-  const [ready, setReady] = React.useState(false);
-
-  React.useEffect(() => {
-    const hashSession = window.location.hash.slice(1);
-    const storedUser = getStoredUser();
-    const hasUser = Boolean(storedUser?.id && storedUser?.name);
-
-    if (!hashSession) {
-      router.replace('/voting');
-      return;
-    }
-
-    if (!hasUser) {
-      router.replace(`/voting#${hashSession}`);
-      return;
-    }
-
-    setSession(hashSession);
-    setUser(storedUser);
-    setReady(true);
-  }, [router]);
+  const { session, user, ready } = useHashSession();
 
   return (
     <>

--- a/pages/options.jsx
+++ b/pages/options.jsx
@@ -3,6 +3,7 @@ import Head from 'next/head';
 import { useRouter } from 'next/router';
 import Layout from '../src/components/Layout';
 import { OptionsScreen } from '../src/components/OptionsScreen';
+import { getStoredUser } from '../src/utils/userStorage';
 
 const Options = () => {
   const router = useRouter();
@@ -12,7 +13,7 @@ const Options = () => {
 
   React.useEffect(() => {
     const hashSession = window.location.hash.slice(1);
-    const storedUser = JSON.parse(localStorage.getItem('user') || 'null');
+    const storedUser = getStoredUser();
     const hasUser = Boolean(storedUser?.id && storedUser?.name);
 
     if (!hashSession) {

--- a/pages/results.jsx
+++ b/pages/results.jsx
@@ -1,35 +1,11 @@
 import React from 'react';
 import Head from 'next/head';
-import { useRouter } from 'next/router';
 import Layout from '../src/components/Layout';
 import { ResultsScreen } from '../src/components/ResultsScreen';
-import { getStoredUser } from '../src/utils/userStorage';
+import { useHashSession } from '../src/hooks/useHashSession';
 
 const Results = () => {
-  const router = useRouter();
-  const [session, setSession] = React.useState('');
-  const [user, setUser] = React.useState();
-  const [ready, setReady] = React.useState(false);
-
-  React.useEffect(() => {
-    const hashSession = window.location.hash.slice(1);
-    const storedUser = getStoredUser();
-    const hasUser = Boolean(storedUser?.id && storedUser?.name);
-
-    if (!hashSession) {
-      router.replace('/voting');
-      return;
-    }
-
-    if (!hasUser) {
-      router.replace(`/voting#${hashSession}`);
-      return;
-    }
-
-    setSession(hashSession);
-    setUser(storedUser);
-    setReady(true);
-  }, [router]);
+  const { session, user, ready } = useHashSession();
 
   return (
     <>

--- a/pages/results.jsx
+++ b/pages/results.jsx
@@ -3,6 +3,7 @@ import Head from 'next/head';
 import { useRouter } from 'next/router';
 import Layout from '../src/components/Layout';
 import { ResultsScreen } from '../src/components/ResultsScreen';
+import { getStoredUser } from '../src/utils/userStorage';
 
 const Results = () => {
   const router = useRouter();
@@ -12,7 +13,7 @@ const Results = () => {
 
   React.useEffect(() => {
     const hashSession = window.location.hash.slice(1);
-    const storedUser = JSON.parse(localStorage.getItem('user') || 'null');
+    const storedUser = getStoredUser();
     const hasUser = Boolean(storedUser?.id && storedUser?.name);
 
     if (!hashSession) {

--- a/pages/voting.jsx
+++ b/pages/voting.jsx
@@ -5,6 +5,7 @@ import { useRouter } from 'next/router';
 import Layout from '../src/components/Layout';
 import { VotingScreen } from '../src/components/VotingScreen';
 import * as styles from '../src/components/JoinSessionPrompt/joinsessionprompt.module.css';
+import { getStoredUser, setStoredUser } from '../src/utils/userStorage';
 
 const Voting = () => {
   const router = useRouter();
@@ -15,7 +16,7 @@ const Voting = () => {
 
   React.useEffect(() => {
     const hashSession = window.location.hash.slice(1);
-    const storedUser = JSON.parse(localStorage.getItem('user') || 'null');
+    const storedUser = getStoredUser();
     const hasUser = Boolean(storedUser?.id && storedUser?.name);
 
     if (!hashSession) {
@@ -48,7 +49,7 @@ const Voting = () => {
         id: globalThis.crypto.randomUUID(),
         name: normalizedName,
       };
-      localStorage.setItem('user', JSON.stringify(nextUser));
+      setStoredUser(nextUser);
       setUser(nextUser);
       setReady(true);
     },

--- a/pages/voting.jsx
+++ b/pages/voting.jsx
@@ -5,7 +5,11 @@ import { useRouter } from 'next/router';
 import Layout from '../src/components/Layout';
 import { VotingScreen } from '../src/components/VotingScreen';
 import * as styles from '../src/components/JoinSessionPrompt/joinsessionprompt.module.css';
-import { getStoredUser, setStoredUser } from '../src/utils/userStorage';
+import {
+  getStoredUser,
+  getStoredUserName,
+  setStoredUser,
+} from '../src/utils/userStorage';
 
 const Voting = () => {
   const router = useRouter();
@@ -16,14 +20,16 @@ const Voting = () => {
 
   React.useEffect(() => {
     const hashSession = window.location.hash.slice(1);
-    const storedUser = getStoredUser();
-    const hasUser = Boolean(storedUser?.id && storedUser?.name);
 
     if (!hashSession) {
       const nextSession = nanoid(7);
       router.replace(`/voting#${nextSession}`);
       return;
     }
+
+    const storedUser = getStoredUser(hashSession);
+    const storedName = getStoredUserName();
+    const hasUser = Boolean(storedUser?.id && storedUser?.name);
 
     setSession(hashSession);
     if (hasUser) {
@@ -34,6 +40,7 @@ const Voting = () => {
     }
 
     setUser(undefined);
+    setNameInput(storedName || '');
     setReady(false);
   }, [router]);
 
@@ -49,11 +56,11 @@ const Voting = () => {
         id: globalThis.crypto.randomUUID(),
         name: normalizedName,
       };
-      setStoredUser(nextUser);
+      setStoredUser(nextUser, session);
       setUser(nextUser);
       setReady(true);
     },
-    [nameInput],
+    [nameInput, session],
   );
 
   return (

--- a/src/api/users.js
+++ b/src/api/users.js
@@ -18,10 +18,7 @@ export const createUser = async (session, user) => {
 
   const { data: newUser, error } = await supabase
     .from('users')
-    .upsert(
-      [payload],
-      { onConflict: 'id' },
-    )
+    .upsert([payload], { onConflict: 'id' })
     .select()
     .single();
 

--- a/src/api/users.js
+++ b/src/api/users.js
@@ -5,17 +5,21 @@ export const createUser = async (session, user) => {
     throw new Error('User id and name are required');
   }
 
+  const payload = {
+    id: user.id,
+    name: user.name,
+    session_name: session,
+    last_presence: new Date().toISOString(),
+  };
+
+  if (typeof user.is_spectator === 'boolean') {
+    payload.is_spectator = user.is_spectator;
+  }
+
   const { data: newUser, error } = await supabase
     .from('users')
     .upsert(
-      [
-        {
-          id: user.id,
-          name: user.name,
-          session_name: session,
-          last_presence: new Date().toISOString(),
-        },
-      ],
+      [payload],
       { onConflict: 'id' },
     )
     .select()

--- a/src/components/Hero/index.jsx
+++ b/src/components/Hero/index.jsx
@@ -2,6 +2,12 @@ import React from 'react';
 import { nanoid } from 'nanoid';
 import { PlanningPoker } from '../PlanningPoker';
 import * as styles from './hero.module.css';
+import {
+  clearStoredUser,
+  getStoredUser,
+  normalizeStoredUser,
+  setStoredUser,
+} from '../../utils/userStorage';
 
 export const Hero = () => {
   const [session, setSession] = React.useState('');
@@ -9,20 +15,12 @@ export const Hero = () => {
   const [nameInput, setNameInput] = React.useState('');
   const hasUser = Boolean(user?.id && user?.name);
 
-  const normalizeUser = React.useCallback(storedUser => {
-    if (!storedUser?.name) return;
-    return {
-      id: storedUser.id || globalThis.crypto.randomUUID(),
-      name: storedUser.name,
-    };
-  }, []);
-
   const onHashChange = React.useCallback(() => {
     setSession(window.location.hash.slice(1));
   }, []);
 
   const createOrRestoreUser = React.useCallback(() => {
-    const storedUser = normalizeUser(JSON.parse(localStorage.getItem('user')));
+    const storedUser = getStoredUser();
     if (storedUser) {
       setUser(storedUser);
       setNameInput(storedUser.name);
@@ -30,7 +28,7 @@ export const Hero = () => {
     }
 
     setUser(undefined);
-  }, [normalizeUser]);
+  }, []);
 
   React.useEffect(() => {
     window.addEventListener('hashchange', onHashChange);
@@ -45,7 +43,7 @@ export const Hero = () => {
       return;
     }
 
-    localStorage.setItem('user', JSON.stringify(user));
+    setStoredUser(user);
   }, [user]);
 
   const ensureUser = React.useCallback(() => {
@@ -58,10 +56,10 @@ export const Hero = () => {
       return null;
     }
 
-    const nextUser = normalizeUser({ name: normalizedName });
+    const nextUser = normalizeStoredUser({ name: normalizedName });
     setUser(nextUser);
     return nextUser;
-  }, [nameInput, normalizeUser, user]);
+  }, [nameInput, user]);
 
   const createSession = React.useCallback(() => {
     if (typeof window === 'undefined') {
@@ -87,7 +85,7 @@ export const Hero = () => {
   );
 
   const clearIdentity = React.useCallback(() => {
-    localStorage.removeItem('user');
+    clearStoredUser();
     setUser(undefined);
     setNameInput('');
   }, []);

--- a/src/components/Hero/index.jsx
+++ b/src/components/Hero/index.jsx
@@ -5,6 +5,7 @@ import * as styles from './hero.module.css';
 import {
   clearStoredUser,
   getStoredUser,
+  getStoredUserName,
   normalizeStoredUser,
   setStoredUser,
 } from '../../utils/userStorage';
@@ -16,11 +17,12 @@ export const Hero = () => {
   const hasUser = Boolean(user?.id && user?.name);
 
   const onHashChange = React.useCallback(() => {
-    setSession(window.location.hash.slice(1));
-  }, []);
+    const nextSession = window.location.hash.slice(1);
+    const storedUser = nextSession ? getStoredUser(nextSession) : undefined;
+    const storedName = getStoredUserName();
 
-  const createOrRestoreUser = React.useCallback(() => {
-    const storedUser = getStoredUser();
+    setSession(nextSession);
+
     if (storedUser) {
       setUser(storedUser);
       setNameInput(storedUser.name);
@@ -28,23 +30,23 @@ export const Hero = () => {
     }
 
     setUser(undefined);
+    setNameInput(storedName || '');
   }, []);
 
   React.useEffect(() => {
     window.addEventListener('hashchange', onHashChange);
     onHashChange();
-    createOrRestoreUser();
 
     return () => window.removeEventListener('hashchange', onHashChange);
-  }, [createOrRestoreUser, onHashChange]);
+  }, [onHashChange]);
 
   React.useEffect(() => {
-    if (!user?.id || !user?.name) {
+    if (!user?.id || !user?.name || !session) {
       return;
     }
 
-    setStoredUser(user);
-  }, [user]);
+    setStoredUser(user, session);
+  }, [session, user]);
 
   const ensureUser = React.useCallback(() => {
     if (user?.id && user?.name) {
@@ -65,17 +67,23 @@ export const Hero = () => {
     if (typeof window === 'undefined') {
       return;
     }
-    if (!ensureUser()) {
+    const nextSession = nanoid(7);
+    const nextUser = ensureUser();
+    if (!nextUser) {
       return;
     }
-    window.location.hash = nanoid(7);
+    setStoredUser(nextUser, nextSession);
+    window.location.hash = nextSession;
   }, [ensureUser]);
 
   const onSubmitName = React.useCallback(
     event => {
       event.preventDefault();
       if (session) {
-        ensureUser();
+        const nextUser = ensureUser();
+        if (nextUser) {
+          setStoredUser(nextUser, session);
+        }
         return;
       }
 

--- a/src/components/OptionsScreen/index.jsx
+++ b/src/components/OptionsScreen/index.jsx
@@ -1,12 +1,12 @@
 import React from 'react';
 import { useRouter } from 'next/router';
 import { POINT_SEQUENCES, useSessionState } from '../../hooks/useSessionState';
+import { useTheme } from '../../hooks/useTheme';
 import { submitOption } from '../../api/options';
 import { OPT_POINT_KEY } from '../../api/options';
 import * as styles from './optionsscreen.module.css';
 
 export const OptionsScreen = ({ session, user: localUser }) => {
-  const storageKey = 'prefers-dark-mode';
   const router = useRouter();
   const {
     user,
@@ -20,9 +20,9 @@ export const OptionsScreen = ({ session, user: localUser }) => {
     setUserName,
   } = useSessionState({ session, localUser });
 
+  const [themeMode, setThemeMode] = useTheme();
   const [userNameInput, setUserNameInput] = React.useState('');
   const [sessionNameInput, setSessionNameInput] = React.useState('');
-  const [themeMode, setThemeMode] = React.useState('dark');
 
   React.useEffect(() => {
     setSessionNameInput(sessionDisplayName);
@@ -31,29 +31,6 @@ export const OptionsScreen = ({ session, user: localUser }) => {
   React.useEffect(() => {
     setUserNameInput(user?.name || '');
   }, [user?.name]);
-
-  React.useEffect(() => {
-    const storedValue = window.localStorage.getItem(storageKey);
-    let shouldUseDarkmode = null;
-    if (storedValue !== null) {
-      shouldUseDarkmode = JSON.parse(storedValue);
-    }
-    if (typeof shouldUseDarkmode !== 'boolean') {
-      shouldUseDarkmode = window.matchMedia(
-        '(prefers-color-scheme: dark)',
-      ).matches;
-    }
-    setThemeMode(shouldUseDarkmode ? 'dark' : 'light');
-  }, []);
-
-  React.useEffect(() => {
-    const prefersDarkmode = themeMode === 'dark';
-    document.documentElement.setAttribute(
-      'data-theme',
-      prefersDarkmode ? 'dark' : 'light',
-    );
-    window.localStorage.setItem(storageKey, JSON.stringify(prefersDarkmode));
-  }, [themeMode]);
 
   const handleUserNameSave = React.useCallback(
     e => {

--- a/src/components/OptionsScreen/index.jsx
+++ b/src/components/OptionsScreen/index.jsx
@@ -13,9 +13,11 @@ export const OptionsScreen = ({ session, user: localUser }) => {
     sequence,
     confirmEnabled,
     isModerator,
+    isSpectator,
     sessionDisplayName,
     toggleConfirm,
     setModeratorStatus,
+    setSpectatorStatus,
     setSessionDisplayName,
     setUserName,
   } = useSessionState({ session, localUser });
@@ -191,6 +193,21 @@ export const OptionsScreen = ({ session, user: localUser }) => {
           <p className={styles.hint}>
             Moderators can reveal, reset, and change card types during the
             session.
+          </p>
+        </div>
+
+        <div className={styles.setting}>
+          <span className={styles.label}>Spectator mode</span>
+          <label className={styles.toggle_label}>
+            <input
+              type="checkbox"
+              checked={isSpectator}
+              onChange={e => setSpectatorStatus(e.target.checked)}
+            />
+            <span>{isSpectator ? 'You are spectating' : 'You can vote'}</span>
+          </label>
+          <p className={styles.hint}>
+            Spectators stay visible in the roster but are excluded from voting.
           </p>
         </div>
       </div>

--- a/src/components/ResultsScreen/index.jsx
+++ b/src/components/ResultsScreen/index.jsx
@@ -17,11 +17,12 @@ export const ResultsScreen = ({ session, user: localUser }) => {
   const { rounds, selectedRound, isViewingHistory, selectRound } =
     useRounds({ session });
 
+  const navigatingRef = React.useRef(false);
   React.useEffect(() => {
-    if (stage !== 'voting') {
+    if (stage !== 'voting' || navigatingRef.current) {
       return;
     }
-
+    navigatingRef.current = true;
     router.replace(`/voting#${session}`);
   }, [router, session, stage]);
 

--- a/src/components/ResultsScreen/index.jsx
+++ b/src/components/ResultsScreen/index.jsx
@@ -12,7 +12,7 @@ export const ResultsScreen = ({ session, user: localUser }) => {
   const router = useRouter();
   const [sidebarOpen, setSidebarOpen] = React.useState(false);
   const [isResetting, setIsResetting] = React.useState(false);
-  const { user, users, scores, confirmEnabled, stage, isModerator, sessionDisplayName, sequence, toggleConfirm, setModeratorStatus, setSessionDisplayName, setUserName, setStage } =
+  const { user, users, scores, confirmEnabled, stage, isModerator, isSpectator, sessionDisplayName, sequence, toggleConfirm, setModeratorStatus, setSpectatorStatus, setSessionDisplayName, setUserName, setStage } =
     useSessionState({ session, localUser });
   const { rounds, selectedRound, isViewingHistory, selectRound } =
     useRounds({ session });
@@ -66,9 +66,11 @@ export const ResultsScreen = ({ session, user: localUser }) => {
         sequence={sequence}
         confirmEnabled={confirmEnabled}
         isModerator={isModerator}
+        isSpectator={isSpectator}
         sessionDisplayName={sessionDisplayName}
         toggleConfirm={toggleConfirm}
         setModeratorStatus={setModeratorStatus}
+        setSpectatorStatus={setSpectatorStatus}
         setSessionDisplayName={setSessionDisplayName}
         setUserName={setUserName}
       />

--- a/src/components/ResultsScreen/index.jsx
+++ b/src/components/ResultsScreen/index.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { useRouter } from 'next/router';
+import { toast } from 'react-toastify';
 import { UserList } from '../UserList';
 import { Sidebar } from '../Sidebar';
 import { useSessionState } from '../../hooks/useSessionState';
@@ -10,6 +11,7 @@ import * as styles from './resultsscreen.module.css';
 export const ResultsScreen = ({ session, user: localUser }) => {
   const router = useRouter();
   const [sidebarOpen, setSidebarOpen] = React.useState(false);
+  const [isResetting, setIsResetting] = React.useState(false);
   const { user, users, scores, confirmEnabled, stage, isModerator, sessionDisplayName, sequence, toggleConfirm, setModeratorStatus, setSessionDisplayName, setUserName, setStage } =
     useSessionState({ session, localUser });
   const { rounds, selectedRound, isViewingHistory, selectRound } =
@@ -23,13 +25,21 @@ export const ResultsScreen = ({ session, user: localUser }) => {
     router.replace(`/voting#${session}`);
   }, [router, session, stage]);
 
-  const goToVoting = React.useCallback(() => {
+  const goToVoting = React.useCallback(async () => {
     if (
       isModerator &&
       (!confirmEnabled || window.confirm('Reset scores and go back to voting?'))
     ) {
-      resetScoresWithRound(session, scores, users);
-      setStage('voting');
+      try {
+        setIsResetting(true);
+        await resetScoresWithRound(session, scores, users);
+        setStage('voting');
+      } catch (error) {
+        toast.error('Could not reset scores. Please try again.');
+        console.warn('Failed to reset scores', error);
+      } finally {
+        setIsResetting(false);
+      }
     }
   }, [session, scores, users, isModerator, confirmEnabled, setStage]);
 
@@ -74,14 +84,16 @@ export const ResultsScreen = ({ session, user: localUser }) => {
           type="button"
           className={styles.route}
           onClick={goToVoting}
-          disabled={!isModerator}
+          disabled={!isModerator || isResetting}
           title={
             !isModerator
               ? 'Become a moderator in Session to control the session stage'
-              : ''
+              : isResetting
+                ? 'Resetting scores'
+                : ''
           }
         >
-          Back to voting
+          {isResetting ? 'Resetting...' : 'Back to voting'}
         </button>
       </div>
 

--- a/src/components/RoundDetail/index.jsx
+++ b/src/components/RoundDetail/index.jsx
@@ -1,23 +1,14 @@
 import React from 'react';
 import { SCORE_ICON_MAP } from '../../api/scores';
+import { scoreStats } from '../../utils/scoreStats';
 import * as styles from './rounddetail.module.css';
 
 export const RoundDetail = ({ round }) => {
   const scores = React.useMemo(() => round?.scores || [], [round]);
 
-  const numericScores = React.useMemo(
-    () => scores.filter(score => score.score >= 0).map(score => score.score),
+  const { numericScores, lowest, highest } = React.useMemo(
+    () => scoreStats(scores),
     [scores],
-  );
-
-  const lowest = React.useMemo(
-    () => (numericScores.length ? Math.min(...numericScores) : null),
-    [numericScores],
-  );
-
-  const highest = React.useMemo(
-    () => (numericScores.length ? Math.max(...numericScores) : null),
-    [numericScores],
   );
 
   const sortedScores = React.useMemo(

--- a/src/components/RoundDetail/index.jsx
+++ b/src/components/RoundDetail/index.jsx
@@ -3,11 +3,7 @@ import { SCORE_ICON_MAP } from '../../api/scores';
 import * as styles from './rounddetail.module.css';
 
 export const RoundDetail = ({ round }) => {
-  if (!round || !round.scores) {
-    return <div className={styles.empty}>No scores in this round</div>;
-  }
-
-  const scores = round.scores || [];
+  const scores = React.useMemo(() => round?.scores || [], [round]);
 
   const numericScores = React.useMemo(
     () => scores.filter(score => score.score >= 0).map(score => score.score),
@@ -25,9 +21,30 @@ export const RoundDetail = ({ round }) => {
   );
 
   const sortedScores = React.useMemo(
-    () => [...scores].sort((a, b) => (b.score >= 0 ? 1 : -1)),
+    () =>
+      [...scores].sort((a, b) => {
+        const aScore = Number(a.score);
+        const bScore = Number(b.score);
+        const aIsNumeric = Number.isFinite(aScore) && aScore >= 0;
+        const bIsNumeric = Number.isFinite(bScore) && bScore >= 0;
+
+        if (aIsNumeric && bIsNumeric) {
+          return bScore - aScore;
+        }
+        if (aIsNumeric) {
+          return -1;
+        }
+        if (bIsNumeric) {
+          return 1;
+        }
+        return String(a.score).localeCompare(String(b.score));
+      }),
     [scores],
   );
+
+  if (!scores.length) {
+    return <div className={styles.empty}>No scores in this round</div>;
+  }
 
   return (
     <div className={styles.round_detail}>

--- a/src/components/ScoreCards/index.jsx
+++ b/src/components/ScoreCards/index.jsx
@@ -8,7 +8,7 @@ import * as styles from './scorecards.module.css';
 export const ScoreCards = ({ options, session, selectedScore }) => {
   const onSelectCard = React.useCallback(
     async value => {
-      const user = getStoredUser();
+      const user = getStoredUser(session);
       if (!user?.id) return;
 
       const deleteValue = '-';

--- a/src/components/ScoreCards/index.jsx
+++ b/src/components/ScoreCards/index.jsx
@@ -1,21 +1,28 @@
 import React from 'react';
+import { toast } from 'react-toastify';
 import { submitScore, deleteScore, ICON_SCORE_MAP } from '../../api/scores';
+import { getStoredUser } from '../../utils/userStorage';
 
 import * as styles from './scorecards.module.css';
 
 export const ScoreCards = ({ options, session, selectedScore }) => {
   const onSelectCard = React.useCallback(
-    value => {
-      const user = JSON.parse(localStorage.getItem('user'));
+    async value => {
+      const user = getStoredUser();
       if (!user?.id) return;
 
       const deleteValue = '-';
       const scoreValue = ICON_SCORE_MAP[value] || value;
 
-      if (value === deleteValue) {
-        deleteScore(session, user.id);
-      } else {
-        submitScore(session, user.id, scoreValue);
+      try {
+        if (value === deleteValue) {
+          await deleteScore(session, user.id);
+        } else {
+          await submitScore(session, user.id, scoreValue);
+        }
+      } catch (error) {
+        toast.error('Could not submit score. Please try again.');
+        console.warn('Failed to submit score', error);
       }
     },
     [session],

--- a/src/components/ScoreCards/index.jsx
+++ b/src/components/ScoreCards/index.jsx
@@ -5,7 +5,12 @@ import { getStoredUser } from '../../utils/userStorage';
 
 import * as styles from './scorecards.module.css';
 
-export const ScoreCards = ({ options, session, selectedScore }) => {
+export const ScoreCards = ({
+  options,
+  session,
+  selectedScore,
+  onBecomeSpectator,
+}) => {
   const onSelectCard = React.useCallback(
     async value => {
       const user = getStoredUser(session);
@@ -53,6 +58,15 @@ export const ScoreCards = ({ options, session, selectedScore }) => {
           </button>
         ))}
       </div>
+      {onBecomeSpectator ? (
+        <button
+          type="button"
+          className={styles.spectator_link}
+          onClick={onBecomeSpectator}
+        >
+          Become a spectator
+        </button>
+      ) : null}
     </div>
   );
 };

--- a/src/components/ScoreCards/scorecards.module.css
+++ b/src/components/ScoreCards/scorecards.module.css
@@ -1,6 +1,7 @@
 .card_container {
   display: flex;
   flex-direction: column;
+  align-items: center;
   text-align: center;
   margin-top: 1rem;
 }
@@ -45,6 +46,22 @@
   background: color-mix(in srgb, var(--color-discord-blue), var(--surface-accent) 80%);
 }
 
+.spectator_link {
+  border: none;
+  background: transparent;
+  color: var(--text-color-subtle);
+  font-size: 0.82rem;
+  line-height: 1.2;
+  text-decoration: underline;
+  text-underline-offset: 2px;
+  cursor: pointer;
+  padding: 0;
+}
+
+.spectator_link:hover {
+  color: var(--text-color);
+}
+
 @media (max-width: 768px) {
   .card_container {
     margin-top: 16px;
@@ -61,5 +78,9 @@
     min-width: 4.5rem;
     min-height: 4.5rem;
     font-size: 1.35rem;
+  }
+
+  .spectator_link {
+    display: none;
   }
 }

--- a/src/components/Sidebar/index.jsx
+++ b/src/components/Sidebar/index.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { POINT_SEQUENCES } from '../../hooks/useSessionState';
+import { useTheme } from '../../hooks/useTheme';
 import { submitOption } from '../../api/options';
 import { OPT_POINT_KEY } from '../../api/options';
 import { RoundsList } from '../RoundsList';
@@ -23,11 +24,10 @@ export const Sidebar = ({
   setSessionDisplayName,
   setUserName,
 }) => {
-  const storageKey = 'prefers-dark-mode';
+  const [themeMode, setThemeMode] = useTheme();
   const [activeTab, setActiveTab] = React.useState('rounds');
   const [userNameInput, setUserNameInput] = React.useState('');
   const [sessionNameInput, setSessionNameInput] = React.useState('');
-  const [themeMode, setThemeMode] = React.useState('dark');
 
   React.useEffect(() => {
     setSessionNameInput(sessionDisplayName);
@@ -36,29 +36,6 @@ export const Sidebar = ({
   React.useEffect(() => {
     setUserNameInput(user?.name || '');
   }, [user?.name]);
-
-  React.useEffect(() => {
-    const storedValue = window.localStorage.getItem(storageKey);
-    let shouldUseDarkmode = null;
-    if (storedValue !== null) {
-      shouldUseDarkmode = JSON.parse(storedValue);
-    }
-    if (typeof shouldUseDarkmode !== 'boolean') {
-      shouldUseDarkmode = window.matchMedia(
-        '(prefers-color-scheme: dark)',
-      ).matches;
-    }
-    setThemeMode(shouldUseDarkmode ? 'dark' : 'light');
-  }, []);
-
-  React.useEffect(() => {
-    const prefersDarkmode = themeMode === 'dark';
-    document.documentElement.setAttribute(
-      'data-theme',
-      prefersDarkmode ? 'dark' : 'light',
-    );
-    window.localStorage.setItem(storageKey, JSON.stringify(prefersDarkmode));
-  }, [themeMode]);
 
   const handleUserNameSave = React.useCallback(
     e => {

--- a/src/components/Sidebar/index.jsx
+++ b/src/components/Sidebar/index.jsx
@@ -18,9 +18,11 @@ export const Sidebar = ({
   sequence,
   confirmEnabled,
   isModerator,
+  isSpectator,
   sessionDisplayName,
   toggleConfirm,
   setModeratorStatus,
+  setSpectatorStatus,
   setSessionDisplayName,
   setUserName,
 }) => {
@@ -239,6 +241,22 @@ export const Sidebar = ({
                     />
                     <span>
                       {isModerator ? 'You are a moderator' : 'Not a moderator'}
+                    </span>
+                  </label>
+                </div>
+
+                <div className={styles.setting}>
+                  <span className={styles.label}>Spectator mode</span>
+                  <label className={styles.toggle_label}>
+                    <input
+                      type="checkbox"
+                      checked={isSpectator}
+                      onChange={e => setSpectatorStatus?.(e.target.checked)}
+                    />
+                    <span>
+                      {isSpectator
+                        ? 'You are spectating'
+                        : 'You can submit votes'}
                     </span>
                   </label>
                 </div>

--- a/src/components/UserList/index.jsx
+++ b/src/components/UserList/index.jsx
@@ -40,14 +40,14 @@ export const UserList = ({ me, users, scores, forceReveal = false }) => {
   const sortedUsers = React.useMemo(() => {
     const ordered = [...(users || [])].sort((a, b) => a.id.localeCompare(b.id));
     if (showScores) {
-      return ordered.sort(
-        (a, b) => {
-          if (a.is_spectator !== b.is_spectator) {
-            return a.is_spectator ? 1 : -1;
-          }
-          return (scoreByUser[b.id]?.score ?? 0) - (scoreByUser[a.id]?.score ?? 0);
-        },
-      );
+      return ordered.sort((a, b) => {
+        if (a.is_spectator !== b.is_spectator) {
+          return a.is_spectator ? 1 : -1;
+        }
+        return (
+          (scoreByUser[b.id]?.score ?? 0) - (scoreByUser[a.id]?.score ?? 0)
+        );
+      });
     }
     return ordered;
   }, [users, showScores, scoreByUser]);

--- a/src/components/UserList/index.jsx
+++ b/src/components/UserList/index.jsx
@@ -4,10 +4,28 @@ import { SCORE_ICON_MAP } from '../../api/scores';
 import { scoreStats } from '../../utils/scoreStats';
 
 export const UserList = ({ me, users, scores, forceReveal = false }) => {
-  const { numericScores, lowest, highest, avg, stddev } = React.useMemo(
-    () => scoreStats(scores),
-    [scores],
+  const userById = React.useMemo(() => {
+    const byId = {};
+    (users || []).forEach(user => {
+      byId[user.id] = user;
+    });
+    return byId;
+  }, [users]);
+
+  const scoringUserScores = React.useMemo(
+    () =>
+      (scores || []).filter(score => {
+        const scoreUser = userById[score.user_id];
+        return !scoreUser?.is_spectator;
+      }),
+    [scores, userById],
   );
+
+  const { numericScores, lowest, highest, avg, stddev } = React.useMemo(
+    () => scoreStats(scoringUserScores),
+    [scoringUserScores],
+  );
+
   const scoreByUser = React.useMemo(() => {
     const byUser = {};
     scores?.forEach(score => {
@@ -23,8 +41,12 @@ export const UserList = ({ me, users, scores, forceReveal = false }) => {
     const ordered = [...(users || [])].sort((a, b) => a.id.localeCompare(b.id));
     if (showScores) {
       return ordered.sort(
-        (a, b) =>
-          (scoreByUser[b.id]?.score ?? 0) - (scoreByUser[a.id]?.score ?? 0),
+        (a, b) => {
+          if (a.is_spectator !== b.is_spectator) {
+            return a.is_spectator ? 1 : -1;
+          }
+          return (scoreByUser[b.id]?.score ?? 0) - (scoreByUser[a.id]?.score ?? 0);
+        },
       );
     }
     return ordered;
@@ -47,6 +69,7 @@ export const UserList = ({ me, users, scores, forceReveal = false }) => {
   const User = ({ user }) => {
     const isMe = user.id === me?.id;
     const score = scoreByUser[user.id];
+    const isSpectator = Boolean(user.is_spectator);
     const hasSubmittedScore = !!score;
     return (
       <li
@@ -56,6 +79,7 @@ export const UserList = ({ me, users, scores, forceReveal = false }) => {
         <div className={`${styles.name} ${isMe ? styles.me : ''}`}>
           {user.name}
           {isMe ? ' (You)' : ''}
+          {isSpectator ? ' (Spectator)' : ''}
         </div>
         <div className={`${styles.card} ${styles.no_hover}`}>
           <Score {...{ isMe, score }} />

--- a/src/components/UserList/index.jsx
+++ b/src/components/UserList/index.jsx
@@ -1,38 +1,12 @@
 import React from 'react';
 import * as styles from './userlist.module.css';
 import { SCORE_ICON_MAP } from '../../api/scores';
-
-const standardDeviation = array => {
-  const n = array.length;
-  if (!n) return NaN;
-  const mean = array.reduce((a, b) => a + b) / n;
-  return Math.sqrt(
-    array.map(x => Math.pow(x - mean, 2)).reduce((a, b) => a + b) / n,
-  );
-};
-
-const average = arr => arr.reduce((p, c) => p + c, 0) / arr.length;
+import { scoreStats } from '../../utils/scoreStats';
 
 export const UserList = ({ me, users, scores, forceReveal = false }) => {
-  const numericScores = React.useMemo(
-    () => scores.filter(score => score.score >= 0).map(score => score.score),
+  const { numericScores, lowest, highest, avg, stddev } = React.useMemo(
+    () => scoreStats(scores),
     [scores],
-  );
-  const lowest = React.useMemo(
-    () => (numericScores.length ? Math.min(...numericScores) : null),
-    [numericScores],
-  );
-  const highest = React.useMemo(
-    () => (numericScores.length ? Math.max(...numericScores) : null),
-    [numericScores],
-  );
-  const stddev = React.useMemo(
-    () => (numericScores.length ? standardDeviation(numericScores) : null),
-    [numericScores],
-  );
-  const avg = React.useMemo(
-    () => (numericScores.length ? average(numericScores) : null),
-    [numericScores],
   );
   const scoreByUser = React.useMemo(() => {
     const byUser = {};

--- a/src/components/VotingScreen/index.jsx
+++ b/src/components/VotingScreen/index.jsx
@@ -20,10 +20,12 @@ export const VotingScreen = ({ session, user: localUser }) => {
     sequence,
     stage,
     isModerator,
+    isSpectator,
     sessionDisplayName,
     confirmEnabled,
     toggleConfirm,
     setModeratorStatus,
+    setSpectatorStatus,
     setSessionDisplayName,
     setUserName,
     setStage,
@@ -58,6 +60,15 @@ export const VotingScreen = ({ session, user: localUser }) => {
     setStage('results');
   }, [setStage]);
 
+  const becomeSpectator = React.useCallback(async () => {
+    try {
+      await setSpectatorStatus(true);
+    } catch (error) {
+      toast.error('Could not switch to spectator mode. Please try again.');
+      console.warn('Failed to switch spectator status', error);
+    }
+  }, [setSpectatorStatus]);
+
   return (
     <div className={styles.container}>
       <button
@@ -80,9 +91,11 @@ export const VotingScreen = ({ session, user: localUser }) => {
         sequence={sequence}
         confirmEnabled={confirmEnabled}
         isModerator={isModerator}
+        isSpectator={isSpectator}
         sessionDisplayName={sessionDisplayName}
         toggleConfirm={toggleConfirm}
         setModeratorStatus={setModeratorStatus}
+        setSpectatorStatus={setSpectatorStatus}
         setSessionDisplayName={setSessionDisplayName}
         setUserName={setUserName}
       />
@@ -122,11 +135,18 @@ export const VotingScreen = ({ session, user: localUser }) => {
             invite new members +
           </button>
           <div className={styles.sticky_cards}>
-            <ScoreCards
-              session={session}
-              options={POINT_SEQUENCES[sequence]}
-              selectedScore={userScore?.score}
-            />
+            {isSpectator ? (
+              <p className={styles.spectator_hint}>
+                Spectator mode is enabled. Switch it off in Options to vote.
+              </p>
+            ) : (
+              <ScoreCards
+                session={session}
+                options={POINT_SEQUENCES[sequence]}
+                selectedScore={userScore?.score}
+                onBecomeSpectator={becomeSpectator}
+              />
+            )}
           </div>
         </div>
       </section>

--- a/src/components/VotingScreen/index.jsx
+++ b/src/components/VotingScreen/index.jsx
@@ -39,11 +39,12 @@ export const VotingScreen = ({ session, user: localUser }) => {
     }
   }, [clipboardState]);
 
+  const navigatingRef = React.useRef(false);
   React.useEffect(() => {
-    if (stage !== 'results') {
+    if (stage !== 'results' || navigatingRef.current) {
       return;
     }
-
+    navigatingRef.current = true;
     router.replace(`/results#${session}`);
   }, [router, session, stage]);
 

--- a/src/components/VotingScreen/votingscreen.module.css
+++ b/src/components/VotingScreen/votingscreen.module.css
@@ -33,6 +33,13 @@
   border-top: 1px solid var(--border-color);
 }
 
+.spectator_hint {
+  margin: 0;
+  text-align: center;
+  color: var(--text-color-subtle);
+  font-weight: 600;
+}
+
 .header h1 {
   font-size: clamp(1.9rem, 3vw, 2.6rem);
   letter-spacing: -0.02em;

--- a/src/hooks/useHashSession.js
+++ b/src/hooks/useHashSession.js
@@ -1,0 +1,40 @@
+import React from 'react';
+import { useRouter } from 'next/router';
+import { getStoredUser } from '../utils/userStorage';
+
+/**
+ * Bootstraps session + user from the URL hash and localStorage.
+ * If there is no hash, redirects to `fallbackPath`.
+ * If there is a hash but no stored user, redirects to `/voting#<hash>`.
+ *
+ * @param {string} [fallbackPath='/voting'] - Where to redirect when the hash is absent.
+ * @returns {{ session: string, user: object|undefined, ready: boolean }}
+ */
+export const useHashSession = (fallbackPath = '/voting') => {
+  const router = useRouter();
+  const [session, setSession] = React.useState('');
+  const [user, setUser] = React.useState();
+  const [ready, setReady] = React.useState(false);
+
+  React.useEffect(() => {
+    const hashSession = window.location.hash.slice(1);
+    const storedUser = getStoredUser();
+    const hasUser = Boolean(storedUser?.id && storedUser?.name);
+
+    if (!hashSession) {
+      router.replace(fallbackPath);
+      return;
+    }
+
+    if (!hasUser) {
+      router.replace(`/voting#${hashSession}`);
+      return;
+    }
+
+    setSession(hashSession);
+    setUser(storedUser);
+    setReady(true);
+  }, [router, fallbackPath]);
+
+  return { session, user, ready };
+};

--- a/src/hooks/useHashSession.js
+++ b/src/hooks/useHashSession.js
@@ -18,13 +18,14 @@ export const useHashSession = (fallbackPath = '/voting') => {
 
   React.useEffect(() => {
     const hashSession = window.location.hash.slice(1);
-    const storedUser = getStoredUser();
-    const hasUser = Boolean(storedUser?.id && storedUser?.name);
 
     if (!hashSession) {
       router.replace(fallbackPath);
       return;
     }
+
+    const storedUser = getStoredUser(hashSession);
+    const hasUser = Boolean(storedUser?.id && storedUser?.name);
 
     if (!hasUser) {
       router.replace(`/voting#${hashSession}`);

--- a/src/hooks/useRounds.js
+++ b/src/hooks/useRounds.js
@@ -6,43 +6,81 @@ export const useRounds = ({ session }) => {
   const [rounds, setRounds] = React.useState([]);
   const [selectedRound, setSelectedRound] = React.useState(null);
   const [isViewingHistory, setIsViewingHistory] = React.useState(false);
+  const sessionRef = React.useRef(session);
+  const roundsRequestRef = React.useRef(0);
 
-  // Fetch initial rounds
   React.useEffect(() => {
-    if (!session) return;
-
-    (async () => {
-      try {
-        const initialRounds = await fetchRounds(session);
-        setRounds(initialRounds);
-      } catch (err) {
-        // Silently ignore errors - rounds table might not exist yet or not be accessible
-        console.warn('Failed to fetch rounds:', err);
-        setRounds([]);
-      }
-    })();
+    sessionRef.current = session;
   }, [session]);
 
-  // Subscribe to new rounds
-  React.useEffect(() => {
-    if (!session) return;
+  const refreshRounds = React.useCallback(async currentSession => {
+    if (!currentSession) {
+      setRounds([]);
+      setSelectedRound(null);
+      setIsViewingHistory(false);
+      return;
+    }
 
-    const handleNewRound = payload => {
-      if (payload.eventType === 'INSERT') {
-        setRounds(currentRounds => [payload.new, ...currentRounds]);
-      } else if (payload.eventType === 'DELETE') {
-        setRounds(currentRounds =>
-          currentRounds.filter(r => r.id !== payload.old.id),
-        );
+    const requestId = ++roundsRequestRef.current;
+
+    try {
+      const nextRounds = await fetchRounds(currentSession);
+      if (
+        sessionRef.current !== currentSession ||
+        requestId !== roundsRequestRef.current
+      ) {
+        return;
       }
-    };
 
-    const channel = addSubscription(session, 'rounds', handleNewRound);
+      setRounds(nextRounds);
+      setSelectedRound(currentRound => {
+        if (!currentRound) {
+          return null;
+        }
+
+        const nextSelectedRound =
+          nextRounds.find(round => round.id === currentRound.id) || null;
+
+        if (!nextSelectedRound) {
+          setIsViewingHistory(false);
+        }
+
+        return nextSelectedRound;
+      });
+    } catch (err) {
+      if (
+        sessionRef.current !== currentSession ||
+        requestId !== roundsRequestRef.current
+      ) {
+        return;
+      }
+
+      // Silently ignore errors - rounds table might not exist yet or not be accessible
+      console.warn('Failed to fetch rounds:', err);
+      setRounds([]);
+      setSelectedRound(null);
+      setIsViewingHistory(false);
+    }
+  }, []);
+
+  React.useEffect(() => {
+    if (!session) {
+      setRounds([]);
+      setSelectedRound(null);
+      setIsViewingHistory(false);
+      return;
+    }
+
+    const channel = addSubscription(session, 'rounds', () => {
+      refreshRounds(session);
+    });
+
+    refreshRounds(session);
 
     return () => {
       removeSubscription(channel);
     };
-  }, [session]);
+  }, [session, refreshRounds]);
 
   const selectRound = React.useCallback(
     roundId => {

--- a/src/hooks/useSessionState.js
+++ b/src/hooks/useSessionState.js
@@ -14,7 +14,7 @@ import {
   OPT_STAGE_DEFAULT,
   moderatorKey,
 } from '../api/options';
-import { fetchScores, updateAllScores } from '../api/scores';
+import { deleteScore, fetchScores, updateAllScores } from '../api/scores';
 import { createUser, fetchAllUsers, updateUserPresence } from '../api/users';
 
 export const REMOVE_SCORE = '-';
@@ -66,6 +66,7 @@ export const useSessionState = ({ session, localUser }) => {
   }, [user?.id]);
 
   const showScores = scores.length > 0 && scores.every(score => score.revealed);
+  const isSpectator = Boolean(user?.is_spectator);
   const nextSequence =
     POINT_SEQUENCES_SORTED[
       (POINT_SEQUENCES_SORTED.indexOf(sequence) + 1) %
@@ -355,6 +356,30 @@ export const useSessionState = ({ session, localUser }) => {
     [session, user],
   );
 
+  const setSpectatorStatus = React.useCallback(
+    async value => {
+      if (!session || !user?.id) return;
+      const nextValue = Boolean(value);
+
+      const updatedUser = await createUser(session, {
+        ...user,
+        is_spectator: nextValue,
+      });
+
+      setUser(updatedUser);
+      setUsers(currentUsers =>
+        currentUsers.map(currentUser =>
+          currentUser.id === updatedUser.id ? updatedUser : currentUser,
+        ),
+      );
+
+      if (nextValue) {
+        await deleteScore(session, user.id);
+      }
+    },
+    [session, user],
+  );
+
   const setStage = React.useCallback(
     value => {
       if (!session) return;
@@ -375,11 +400,13 @@ export const useSessionState = ({ session, localUser }) => {
     nextSequence,
     stage,
     isModerator,
+    isSpectator,
     sessionDisplayName,
     toggleScores,
     toggleConfirm,
     cycleSequence,
     setModeratorStatus,
+    setSpectatorStatus,
     setSessionDisplayName,
     setStage,
     setUserName,

--- a/src/hooks/useSessionState.js
+++ b/src/hooks/useSessionState.js
@@ -50,6 +50,20 @@ export const useSessionState = ({ session, localUser }) => {
   const [isModerator, setIsModerator] = React.useState(false);
   const [sessionDisplayName, setSessionDisplayNameState] = React.useState('');
   const [stage, setStageState] = React.useState(null);
+  const sessionRef = React.useRef(session);
+  const userIdRef = React.useRef();
+  const usersRequestRef = React.useRef(0);
+  const scoresRequestRef = React.useRef(0);
+  const optionsRequestRef = React.useRef(0);
+  const userRequestRef = React.useRef(0);
+
+  React.useEffect(() => {
+    sessionRef.current = session;
+  }, [session]);
+
+  React.useEffect(() => {
+    userIdRef.current = user?.id;
+  }, [user?.id]);
 
   const showScores = scores.length > 0 && scores.every(score => score.revealed);
   const nextSequence =
@@ -60,7 +74,14 @@ export const useSessionState = ({ session, localUser }) => {
 
   const updateUsers = React.useCallback(async currentSession => {
     if (!currentSession) return;
+    const requestId = ++usersRequestRef.current;
     const allUsers = await fetchAllUsers(currentSession);
+    if (
+      sessionRef.current !== currentSession ||
+      requestId !== usersRequestRef.current
+    ) {
+      return;
+    }
     const afkSeconds = 30; // 3 * the presence timer
     const cutoffTimestamp = Date.now() - afkSeconds * 1000;
     const activeUsers = allUsers.filter(
@@ -93,7 +114,14 @@ export const useSessionState = ({ session, localUser }) => {
         return;
       }
 
+      const requestId = ++userRequestRef.current;
       const newUser = await createUser(currentSession, candidate);
+      if (
+        sessionRef.current !== currentSession ||
+        requestId !== userRequestRef.current
+      ) {
+        return;
+      }
       setUser(newUser);
     },
     [],
@@ -101,144 +129,132 @@ export const useSessionState = ({ session, localUser }) => {
 
   const updateScores = React.useCallback(async currentSession => {
     if (!currentSession) return;
+    const requestId = ++scoresRequestRef.current;
     const nextScores = await fetchScores(currentSession);
+    if (
+      sessionRef.current !== currentSession ||
+      requestId !== scoresRequestRef.current
+    ) {
+      return;
+    }
     setScores(nextScores);
     setScoresLoaded(true);
-  }, []);
-
-  const updateScore = React.useCallback(payload => {
-    const oldUser = payload.new?.user_id;
-    const newScore = {
-      user_id: payload.new?.user_id,
-      score: payload.new?.score,
-      revealed: payload.new?.revealed,
-    };
-    setScores(currentScores => [
-      ...currentScores.filter(score => score.user_id !== oldUser),
-      newScore,
-    ]);
-  }, []);
-
-  const removeScore = React.useCallback(payload => {
-    const oldUser = payload.old?.user_id;
-    setScores(currentScores => [
-      ...currentScores.filter(score => score.user_id !== oldUser),
-    ]);
   }, []);
 
   const updateSessionOptions = React.useCallback(
     async (currentSession, currentUserId) => {
       if (!currentSession) return;
-      const pointSequence = await fetchOption(
-        currentSession,
-        OPT_POINT_KEY,
-        OPT_POINT_SEQ_DEFAULT,
-      );
+      const requestId = ++optionsRequestRef.current;
+      const [pointSequence, confirm, displayName, currentStage, moderatorsValue] =
+        await Promise.all([
+          fetchOption(currentSession, OPT_POINT_KEY, OPT_POINT_SEQ_DEFAULT),
+          fetchOption(currentSession, OPT_CONFIRM_KEY, OPT_CONFIRM_DEFAULT),
+          fetchOption(currentSession, OPT_SESSION_NAME_KEY, ''),
+          fetchOption(currentSession, OPT_STAGE_KEY, OPT_STAGE_DEFAULT),
+          fetchOption(currentSession, OPT_MODERATORS_KEY, ''),
+        ]);
+
+      if (
+        sessionRef.current !== currentSession ||
+        requestId !== optionsRequestRef.current
+      ) {
+        return;
+      }
+
       setSequence(pointSequence);
-
-      const confirm = await fetchOption(
-        currentSession,
-        OPT_CONFIRM_KEY,
-        OPT_CONFIRM_DEFAULT,
-      );
       setConfirmEnabled(confirm === 'true');
-
-      const displayName = await fetchOption(
-        currentSession,
-        OPT_SESSION_NAME_KEY,
-        '',
-      );
       setSessionDisplayNameState(displayName);
-
-      const currentStage = await fetchOption(
-        currentSession,
-        OPT_STAGE_KEY,
-        OPT_STAGE_DEFAULT,
-      );
       setStageState(currentStage);
 
-      if (currentUserId) {
-        const moderatorsValue = await fetchOption(
+      if (!currentUserId) {
+        setIsModerator(false);
+        return;
+      }
+
+      const moderatorIds = parseModeratorIds(moderatorsValue);
+
+      if (moderatorIds.includes(currentUserId)) {
+        setIsModerator(true);
+        return;
+      }
+
+      const legacyModValue = await fetchOption(
+        currentSession,
+        moderatorKey(currentUserId),
+        'false',
+      );
+
+      if (
+        sessionRef.current !== currentSession ||
+        requestId !== optionsRequestRef.current
+      ) {
+        return;
+      }
+
+      const isLegacyModerator = legacyModValue === 'true';
+      setIsModerator(isLegacyModerator);
+
+      if (isLegacyModerator) {
+        submitOption(
           currentSession,
           OPT_MODERATORS_KEY,
-          '',
+          [...new Set([...moderatorIds, currentUserId])].join(','),
         );
-        const moderatorIds = parseModeratorIds(moderatorsValue);
-
-        if (moderatorIds.includes(currentUserId)) {
-          setIsModerator(true);
-          return;
-        }
-
-        const legacyModValue = await fetchOption(
-          currentSession,
-          moderatorKey(currentUserId),
-          'false',
-        );
-        const isLegacyModerator = legacyModValue === 'true';
-        setIsModerator(isLegacyModerator);
-
-        if (isLegacyModerator) {
-          submitOption(
-            currentSession,
-            OPT_MODERATORS_KEY,
-            [...new Set([...moderatorIds, currentUserId])].join(','),
-          );
-        }
       }
     },
     [],
   );
 
   React.useEffect(() => {
-    if (!session) return;
+    if (!session) {
+      setScores([]);
+      setScoresLoaded(false);
+      return;
+    }
+
     setScoresLoaded(false);
-    const subscriptionId = addSubscription(session, 'scores', payload => {
-      if (payload.eventType === 'DELETE') {
-        removeScore(payload);
-      } else {
-        updateScore(payload);
-      }
+    const subscriptionId = addSubscription(session, 'scores', () => {
+      updateScores(session);
     });
+
     updateScores(session);
     return () => removeSubscription(subscriptionId);
-  }, [session, removeScore, updateScore, updateScores]);
+  }, [session, updateScores]);
 
   React.useEffect(() => {
-    if (!session) return;
-    const subscriptionId = addSubscription(session, 'options', payload => {
-      const key = payload.new?.key;
-      switch (key) {
-        case OPT_CONFIRM_KEY:
-          setConfirmEnabled(payload.new?.value === 'true');
-          break;
-        case OPT_POINT_KEY:
-          setSequence(payload.new?.value || OPT_POINT_SEQ_DEFAULT);
-          break;
-        case OPT_SESSION_NAME_KEY:
-          setSessionDisplayNameState(payload.new?.value || '');
-          break;
-        case OPT_STAGE_KEY:
-          setStageState(payload.new?.value || OPT_STAGE_DEFAULT);
-          break;
-        case OPT_MODERATORS_KEY:
-          if (user?.id) {
-            const moderatorIds = parseModeratorIds(payload.new?.value);
-            setIsModerator(moderatorIds.includes(user.id));
-          }
-          break;
-        default:
-          if (key?.startsWith('moderator:')) {
-            // Keep legacy option behavior for older sessions.
-            if (key === moderatorKey(user?.id)) {
-              setIsModerator(payload.new?.value === 'true');
-            }
-          }
-          break;
-      }
+    if (!session) {
+      setConfirmEnabled(OPT_CONFIRM_DEFAULT === 'true');
+      setSequence(OPT_POINT_SEQ_DEFAULT);
+      setSessionDisplayNameState('');
+      setStageState(null);
+      setIsModerator(false);
+      return;
+    }
+
+    const subscriptionId = addSubscription(session, 'options', () => {
+      updateSessionOptions(session, userIdRef.current);
     });
-    updateSessionOptions(session, user?.id);
+
+    updateSessionOptions(session, userIdRef.current);
     return () => removeSubscription(subscriptionId);
+  }, [session, updateSessionOptions]);
+
+  React.useEffect(() => {
+    if (!session) {
+      setUsers([]);
+      return;
+    }
+
+    const subscriptionId = addSubscription(session, 'users', () => {
+      updateUsers(session);
+    });
+
+    updateUsers(session);
+    return () => removeSubscription(subscriptionId);
+  }, [session, updateUsers]);
+
+  React.useEffect(() => {
+    updateSessionOptions(session, user?.id);
   }, [session, user?.id, updateSessionOptions]);
 
   React.useEffect(() => {
@@ -246,12 +262,10 @@ export const useSessionState = ({ session, localUser }) => {
   }, [session, localUser, getOrCreateUser]);
 
   React.useEffect(() => {
-    updateUsers(session);
-
     if (session && user?.id) {
       setStoredUser(user, session);
     }
-  }, [session, user, updateUsers]);
+  }, [session, user]);
 
   React.useEffect(() => {
     if (!session || !user?.id) return;

--- a/src/hooks/useSessionState.js
+++ b/src/hooks/useSessionState.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import { addSubscription, removeSubscription } from '../api/client';
+import { setStoredUser } from '../utils/userStorage';
 import {
   fetchOption,
   submitOption,
@@ -64,8 +65,7 @@ export const useSessionState = ({ session, localUser }) => {
     const cutoffTimestamp = Date.now() - afkSeconds * 1000;
     const activeUsers = allUsers.filter(
       currentUser =>
-        parseISOString(currentUser.last_presence).getTime() >
-        cutoffTimestamp,
+        parseISOString(currentUser.last_presence).getTime() > cutoffTimestamp,
     );
     setUsers(activeUsers);
   }, []);
@@ -248,8 +248,8 @@ export const useSessionState = ({ session, localUser }) => {
   React.useEffect(() => {
     updateUsers(session);
 
-    if (user?.id) {
-      localStorage.setItem('user', JSON.stringify(user));
+    if (session && user?.id) {
+      setStoredUser(user, session);
     }
   }, [session, user, updateUsers]);
 

--- a/src/hooks/useSessionState.js
+++ b/src/hooks/useSessionState.js
@@ -145,14 +145,19 @@ export const useSessionState = ({ session, localUser }) => {
     async (currentSession, currentUserId) => {
       if (!currentSession) return;
       const requestId = ++optionsRequestRef.current;
-      const [pointSequence, confirm, displayName, currentStage, moderatorsValue] =
-        await Promise.all([
-          fetchOption(currentSession, OPT_POINT_KEY, OPT_POINT_SEQ_DEFAULT),
-          fetchOption(currentSession, OPT_CONFIRM_KEY, OPT_CONFIRM_DEFAULT),
-          fetchOption(currentSession, OPT_SESSION_NAME_KEY, ''),
-          fetchOption(currentSession, OPT_STAGE_KEY, OPT_STAGE_DEFAULT),
-          fetchOption(currentSession, OPT_MODERATORS_KEY, ''),
-        ]);
+      const [
+        pointSequence,
+        confirm,
+        displayName,
+        currentStage,
+        moderatorsValue,
+      ] = await Promise.all([
+        fetchOption(currentSession, OPT_POINT_KEY, OPT_POINT_SEQ_DEFAULT),
+        fetchOption(currentSession, OPT_CONFIRM_KEY, OPT_CONFIRM_DEFAULT),
+        fetchOption(currentSession, OPT_SESSION_NAME_KEY, ''),
+        fetchOption(currentSession, OPT_STAGE_KEY, OPT_STAGE_DEFAULT),
+        fetchOption(currentSession, OPT_MODERATORS_KEY, ''),
+      ]);
 
       if (
         sessionRef.current !== currentSession ||

--- a/src/hooks/useTheme.js
+++ b/src/hooks/useTheme.js
@@ -1,0 +1,35 @@
+import React from 'react';
+
+const STORAGE_KEY = 'prefers-dark-mode';
+
+const getInitialTheme = () => {
+  if (typeof window === 'undefined') {
+    return 'dark';
+  }
+  const stored = window.localStorage.getItem(STORAGE_KEY);
+  if (stored !== null) {
+    try {
+      return JSON.parse(stored) ? 'dark' : 'light';
+    } catch {
+      // fall through to media query
+    }
+  }
+  return window.matchMedia('(prefers-color-scheme: dark)').matches
+    ? 'dark'
+    : 'light';
+};
+
+export const useTheme = () => {
+  const [themeMode, setThemeMode] = React.useState(getInitialTheme);
+
+  React.useEffect(() => {
+    const prefersDark = themeMode === 'dark';
+    document.documentElement.setAttribute(
+      'data-theme',
+      prefersDark ? 'dark' : 'light',
+    );
+    window.localStorage.setItem(STORAGE_KEY, JSON.stringify(prefersDark));
+  }, [themeMode]);
+
+  return [themeMode, setThemeMode];
+};

--- a/src/utils/scoreStats.js
+++ b/src/utils/scoreStats.js
@@ -1,0 +1,51 @@
+/**
+ * Returns the numeric subset of a scores array (score >= 0).
+ * @param {Array<{score: number}>} scores
+ * @returns {number[]}
+ */
+export const getNumericScores = scores =>
+  (scores || []).filter(s => s.score >= 0).map(s => s.score);
+
+/**
+ * @param {number[]} nums
+ * @returns {number}
+ */
+export const average = nums => nums.reduce((p, c) => p + c, 0) / nums.length;
+
+/**
+ * @param {number[]} nums
+ * @returns {number}
+ */
+export const standardDeviation = nums => {
+  const n = nums.length;
+  if (!n) return NaN;
+  const mean = average(nums);
+  return Math.sqrt(
+    nums.map(x => Math.pow(x - mean, 2)).reduce((a, b) => a + b) / n,
+  );
+};
+
+/**
+ * Computes summary statistics for a scores array.
+ * @param {Array<{score: number}>} scores
+ * @returns {{ numericScores: number[], lowest: number|null, highest: number|null, avg: number|null, stddev: number|null }}
+ */
+export const scoreStats = scores => {
+  const numericScores = getNumericScores(scores);
+  if (!numericScores.length) {
+    return {
+      numericScores,
+      lowest: null,
+      highest: null,
+      avg: null,
+      stddev: null,
+    };
+  }
+  return {
+    numericScores,
+    lowest: Math.min(...numericScores),
+    highest: Math.max(...numericScores),
+    avg: average(numericScores),
+    stddev: standardDeviation(numericScores),
+  };
+};

--- a/src/utils/userStorage.js
+++ b/src/utils/userStorage.js
@@ -82,7 +82,13 @@ export const normalizeStoredUser = candidate => {
     return;
   }
 
-  return { id, name };
+  return {
+    id,
+    name,
+    ...(typeof candidate.is_spectator === 'boolean'
+      ? { is_spectator: candidate.is_spectator }
+      : {}),
+  };
 };
 
 export const getStoredUserName = () => {

--- a/src/utils/userStorage.js
+++ b/src/utils/userStorage.js
@@ -5,6 +5,8 @@ const normalizeName = value => {
   return value.trim();
 };
 
+const STORAGE_KEY = 'user';
+
 const normalizeId = value => {
   if (typeof value === 'string' && value.trim()) {
     return value;
@@ -26,6 +28,45 @@ const safeParseJSON = value => {
   }
 };
 
+const normalizeStoredProfile = candidate => {
+  const name = normalizeName(candidate?.name);
+  if (!name) {
+    return;
+  }
+  return { name };
+};
+
+const normalizeStoredState = candidate => {
+  if (!candidate || typeof candidate !== 'object') {
+    return { profile: undefined, sessions: {} };
+  }
+
+  if ('id' in candidate || 'name' in candidate) {
+    return {
+      profile: normalizeStoredProfile(candidate),
+      sessions: {},
+    };
+  }
+
+  const profile = normalizeStoredProfile(candidate.profile);
+  const sessions = Object.entries(candidate.sessions || {}).reduce(
+    (result, [session, user]) => {
+      const normalizedSession = normalizeName(session);
+      const normalizedUser = normalizeStoredUser(user);
+      if (normalizedSession && normalizedUser) {
+        result[normalizedSession] = normalizedUser;
+      }
+      return result;
+    },
+    {},
+  );
+
+  return { profile, sessions };
+};
+
+const readStoredState = () =>
+  normalizeStoredState(safeParseJSON(window.localStorage.getItem(STORAGE_KEY)));
+
 export const normalizeStoredUser = candidate => {
   if (!candidate || typeof candidate !== 'object') {
     return;
@@ -44,29 +85,71 @@ export const normalizeStoredUser = candidate => {
   return { id, name };
 };
 
-export const getStoredUser = () => {
+export const getStoredUserName = () => {
   if (typeof window === 'undefined') {
     return;
   }
-  const parsed = safeParseJSON(window.localStorage.getItem('user'));
-  return normalizeStoredUser(parsed);
+  return readStoredState().profile?.name;
 };
 
-export const setStoredUser = user => {
+export const getStoredUser = session => {
+  if (typeof window === 'undefined') {
+    return;
+  }
+  if (!session) {
+    return;
+  }
+  const normalizedSession = normalizeName(session);
+  if (!normalizedSession) {
+    return;
+  }
+  return readStoredState().sessions[normalizedSession];
+};
+
+export const setStoredUser = (user, session) => {
   if (typeof window === 'undefined') {
     return;
   }
   const normalized = normalizeStoredUser(user);
+  const normalizedSession = normalizeName(session);
+
   if (!normalized) {
-    window.localStorage.removeItem('user');
+    if (!normalizedSession) {
+      window.localStorage.removeItem(STORAGE_KEY);
+      return;
+    }
+
+    const currentState = readStoredState();
+    const nextSessions = { ...currentState.sessions };
+    delete nextSessions[normalizedSession];
+
+    window.localStorage.setItem(
+      STORAGE_KEY,
+      JSON.stringify({
+        profile: currentState.profile,
+        sessions: nextSessions,
+      }),
+    );
     return;
   }
-  window.localStorage.setItem('user', JSON.stringify(normalized));
+
+  const currentState = readStoredState();
+  const nextState = {
+    profile: { name: normalized.name },
+    sessions: normalizedSession
+      ? {
+          ...currentState.sessions,
+          [normalizedSession]: normalized,
+        }
+      : currentState.sessions,
+  };
+
+  window.localStorage.setItem(STORAGE_KEY, JSON.stringify(nextState));
 };
 
 export const clearStoredUser = () => {
   if (typeof window === 'undefined') {
     return;
   }
-  window.localStorage.removeItem('user');
+  window.localStorage.removeItem(STORAGE_KEY);
 };

--- a/src/utils/userStorage.js
+++ b/src/utils/userStorage.js
@@ -1,0 +1,72 @@
+const normalizeName = value => {
+  if (typeof value !== 'string') {
+    return '';
+  }
+  return value.trim();
+};
+
+const normalizeId = value => {
+  if (typeof value === 'string' && value.trim()) {
+    return value;
+  }
+  if (typeof globalThis?.crypto?.randomUUID === 'function') {
+    return globalThis.crypto.randomUUID();
+  }
+  return '';
+};
+
+const safeParseJSON = value => {
+  if (!value) {
+    return null;
+  }
+  try {
+    return JSON.parse(value);
+  } catch {
+    return null;
+  }
+};
+
+export const normalizeStoredUser = candidate => {
+  if (!candidate || typeof candidate !== 'object') {
+    return;
+  }
+
+  const name = normalizeName(candidate.name);
+  if (!name) {
+    return;
+  }
+
+  const id = normalizeId(candidate.id);
+  if (!id) {
+    return;
+  }
+
+  return { id, name };
+};
+
+export const getStoredUser = () => {
+  if (typeof window === 'undefined') {
+    return;
+  }
+  const parsed = safeParseJSON(window.localStorage.getItem('user'));
+  return normalizeStoredUser(parsed);
+};
+
+export const setStoredUser = user => {
+  if (typeof window === 'undefined') {
+    return;
+  }
+  const normalized = normalizeStoredUser(user);
+  if (!normalized) {
+    window.localStorage.removeItem('user');
+    return;
+  }
+  window.localStorage.setItem('user', JSON.stringify(normalized));
+};
+
+export const clearStoredUser = () => {
+  if (typeof window === 'undefined') {
+    return;
+  }
+  window.localStorage.removeItem('user');
+};

--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -25,6 +25,7 @@ create table public.users (
   id uuid primary key default gen_random_uuid(),
   session_name text not null,
   name text not null,
+  is_spectator boolean not null default false,
   last_presence timestamptz not null default timezone('utc', now()),
   created_at timestamptz not null default timezone('utc', now()),
   updated_at timestamptz not null default timezone('utc', now())


### PR DESCRIPTION
This pull request introduces several improvements and new features to the planning poker application, focusing on session/user management, spectator mode, documentation, and developer experience. The most important changes are grouped below.

**Session and User Management Improvements:**

* Refactored session and user storage logic to use new utility functions in `src/utils/userStorage.js`, ensuring user identities are stored per session and reducing the risk of overwriting identities across sessions. This affects `Hero`, `Voting`, `debug`, and related pages. [[1]](diffhunk://#diff-602769c269434e06f34b4c59f264531786c8e37bc4560d9ffd218f187a23880cR5-R49) [[2]](diffhunk://#diff-3ad4ce78dafacda93a026234761138736d240ca1507225034a740361a4e25143L18-R33) [[3]](diffhunk://#diff-dfff6ae2ab80f75f632d92c818508c352908039d7cdfe0efadb0d4e946e799a0R7)
* Updated session-aware pages (`options.jsx`, `results.jsx`) to use a new `useHashSession` hook, simplifying session and user retrieval logic. [[1]](diffhunk://#diff-110503808256dc1b3a695ebbf269d95e8953504e7d6cf5eee8855aa7a323b9aaL3-R8) [[2]](diffhunk://#diff-0a2ceba6d412000772bb2bd7046cb95203460deb7e2bcb0bc018e3f53b2c01e7L3-R8)
* Enhanced the debug page to show both the preferred name and session user from storage.

**Spectator Mode Feature:**

* Added support for a "spectator mode" role. Users can now opt in/out of spectating in the `OptionsScreen`, which makes them visible in the roster but excludes them from voting. The backend now stores the `is_spectator` flag in the `users` table. [[1]](diffhunk://#diff-32ce88a1c81a7b4f8b608ffb38eaf8148146022a44edb1c6d34b5e20f9a9dd83R198-R212) [[2]](diffhunk://#diff-51d1db749458927d98743f3e92e1cc0ea74d419213075c18220571e7aaba1877L8-R21)

**Documentation and Developer Experience:**

* Significantly expanded the `README.md` with clearer quick start, scripts, build, deployment, and troubleshooting sections. Added details on Supabase schema, session routing, local user storage, and real-time sync. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L13-R70) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L57-R151)
* Updated the CI workflow (`.github/workflows/deploy.yml`) to run lint checks before building, and switched to the standard `npm run build` script.

**UI and State Management Enhancements:**

* Updated theme mode handling in `OptionsScreen` to use a custom hook (`useTheme`), centralizing theme state management. [[1]](diffhunk://#diff-32ce88a1c81a7b4f8b608ffb38eaf8148146022a44edb1c6d34b5e20f9a9dd83R4-L25) [[2]](diffhunk://#diff-32ce88a1c81a7b4f8b608ffb38eaf8148146022a44edb1c6d34b5e20f9a9dd83L35-L57)
* Improved the results screen to handle score resets more robustly, including error handling and user feedback via toast notifications.

These changes collectively improve user experience, add new functionality, and make the codebase easier to maintain and extend.